### PR TITLE
Fix missing dependencies and build errors

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+rosdep install --from-paths src -i -r -y
+
+colcon build --symlink-install --continue-on-error --cmake-args=-DCMAKE_BUILD_TYPE=Release --parallel-workers $(nproc)

--- a/firstTimeInstall.sh
+++ b/firstTimeInstall.sh
@@ -112,3 +112,20 @@ echo "export GST_PLUGIN_PATH=$GST_PLUGIN_PATH" >> $GSTREAMER_DIR/setupGstreamer.
 echo "Finished building GStreamer"
 
 source ~/.bashrc
+
+echo "Downloading ZED SDK ..."
+cd /tmp
+curl -L https://download.stereolabs.com/zedsdk/4.2/l4t36.4/jetsons?_gl=1*1x76wtq*_gcl_au*MTkzMjE2NTcwLjE3MzQyOTE5OTg -o zed_sdk_installer.run
+chmod +x zed_sdk_installer.run
+./zed_sdk_installer.run -- silent
+echo "Finished downloading ZED SDK ..."
+
+echo "Building Kindr ..."
+cd /tmp
+git clone https://github.com/ANYbotics/kindr.git
+cd kindr/
+mkdir build
+cd build
+cmake .. -DUSE_CMAKE=true
+sudo make install
+echo "Finished building Kindr ..."

--- a/firstTimeInstall.sh
+++ b/firstTimeInstall.sh
@@ -115,7 +115,11 @@ source ~/.bashrc
 
 echo "Downloading ZED SDK ..."
 cd /tmp
-curl -L https://download.stereolabs.com/zedsdk/4.2/l4t36.4/jetsons?_gl=1*1x76wtq*_gcl_au*MTkzMjE2NTcwLjE3MzQyOTE5OTg -o zed_sdk_installer.run
+if [ "$(uname -m)" == "aarch64" ]; then
+curl -L https://stereolabs.sfo2.cdn.digitaloceanspaces.com/zedsdk/4.2/ZED_SDK_Tegra_L4T36.4_v4.2.2.zstd.run -o zed_sdk_installer.run
+else
+curl -L https://download.stereolabs.com/zedsdk/4.2/cu12/ubuntu22 -o zed_sdk_installer.run
+fi
 chmod +x zed_sdk_installer.run
 ./zed_sdk_installer.run -- silent
 echo "Finished downloading ZED SDK ..."


### PR DESCRIPTION
### Build and installation script improvements:

* [`build.sh`](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823R1-R5): Create a build script to make it quicker to build and set consistent build arguments
* [`firstTimeInstall.sh`](diffhunk://#diff-d647bc043621286a29ea2bf75ac1bf1583b007b4a5479685fb6e2c0493d80d20R105-R121): Added commands to download and install the ZED SDK, and to clone, build, and install the Kindr library.

### CMakeLists modification:

* [`src/description/CMakeLists.txt`](diffhunk://#diff-7a9aae956f20080823aea747ef396092901c69950cbd3d04c313d8b8d850c9e6L13-R13): Removed the `meshes` and `urdf` directories from the cmake file since they were not needed and therefore not ported over from 2023_rover