### PR TITLE
chore: remove unnecessary linter checks

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -26,7 +26,3 @@ jobs:
           PYLINT_SCORE_THRESHOLD: 10.0  # You can implement stricter checks here
       - name: Run Black
         run: black --check .
-      - name: Run Prettier
-        run: npx prettier --check "**/*.{js,ts}"
-      - name: Run ESLint
-        run: npx eslint "**/*.{js,ts}"


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/lint-and-format.yml` file, specifically focusing on the linting and formatting steps in the CI workflow.

Changes to CI workflow:

* [`.github/workflows/lint-and-format.yml`](diffhunk://#diff-60395b39061839b3177416592202e101e3e9d52394ab5d27ed094d4e771f0245L29-L32): Removed the steps to run Prettier and ESLint checks, leaving only the Black and pylint check.