### PR TITLE
fix: change pipeline for seperate buffer pool for nvcompositor

### DIFF
--- a/src/camera_streaming/camera_streaming/webrct_node.py
+++ b/src/camera_streaming/camera_streaming/webrct_node.py
@@ -116,7 +116,7 @@ class WebRTCStreamer(Node):
             str: The GStreamer pipeline string ready for launch.
         """
         pipeline = ""
-        compositor = "compositor name=mix"
+        compositor = "nvcompositor name=mix"
         total_width = request.width
         total_height = request.height
         i = 0
@@ -126,10 +126,11 @@ class WebRTCStreamer(Node):
             width = int(source.width * total_width / 100)
             origin_x = int(source.origin_x * total_width / 100)
             origin_y = int(source.origin_y * total_height / 100)
-            pipeline += f'{self.create_source(name)} ! nvvidconv ! capsfilter caps="video/x-raw,height={height},width={width}" ! mix.sink_{i} '
+            pipeline += f'{self.create_source(name)} ! nvvidconv ! mix.sink_{i} '
             compositor += f" sink_{i}::xpos={origin_x} sink_{i}::ypos={origin_y} sink_{i}::height={height} sink_{i}::width={width}"
             i = i + 1
-        video_out = "webrtcsink run-signalling-server=true"
+        video_out = 'queue silent=true ! nvvidconv ! capsfilter caps="video/x-raw" ! webrtcsink run-signalling-server=true'
+
         if self.web_server:
             video_out += f" run-web-server=true web-server-host-addr=http://0.0.0.0:8080/ web-server-directory={self.web_server_path}"
         pipeline += compositor + " ! " + video_out

--- a/src/camera_streaming/camera_streaming/webrct_node.py
+++ b/src/camera_streaming/camera_streaming/webrct_node.py
@@ -126,7 +126,7 @@ class WebRTCStreamer(Node):
             width = int(source.width * total_width / 100)
             origin_x = int(source.origin_x * total_width / 100)
             origin_y = int(source.origin_y * total_height / 100)
-            pipeline += f'{self.create_source(name)} ! nvvidconv ! mix.sink_{i} '
+            pipeline += f"{self.create_source(name)} ! nvvidconv ! mix.sink_{i} "
             compositor += f" sink_{i}::xpos={origin_x} sink_{i}::ypos={origin_y} sink_{i}::height={height} sink_{i}::width={width}"
             i = i + 1
         video_out = 'queue silent=true ! nvvidconv ! capsfilter caps="video/x-raw" ! webrtcsink run-signalling-server=true'


### PR DESCRIPTION
For ROVER-344. Due to how webRTCsink works (using an appsink/src) the nvcompositor can not be in the same buffer pool as the webrtcsink. I am forcing a new buffer pool using caps filter. Techincally this does add an additional copy but that overhead is pretty minimal. Added a Queue to help with seperating process threads.