### PR TITLE
State machine

### DIFF
--- a/src/drive/config/thrustmaster.yaml
+++ b/src/drive/config/thrustmaster.yaml
@@ -1,0 +1,27 @@
+flightstick_control:
+  ros__parameters:
+    drive_mode_button: 12
+    arm_ik_mode_button: 11
+    arm_manual_mode_button: 10
+    nav_mode_button: 13
+    science_mode_button: 14
+
+    drive_mode:
+      throttle:
+        axis: 3
+        min: -1.0
+        max: 1.0
+      forward_axis: 1
+      yaw_axis: 0
+      cam_tilt_axis: 5
+      cam_pan_axis: 4
+      cam_reset: 1
+      cam_next: 3
+      cam_prev: 2
+      cruise_control: 0
+      max_linear: 2.0
+      max_angular: 1.0
+      max_increment: 0.1
+      min_speed: 0.001
+      
+    

--- a/src/drive/launch/flightstick_drive.launch.py
+++ b/src/drive/launch/flightstick_drive.launch.py
@@ -13,6 +13,7 @@ from launch.conditions import IfCondition
 def generate_launch_description():
     """Generate launch description with multiple components."""
     pkg_drive = get_package_share_directory("drive")
+    parameters_file = os.path.join(pkg_drive, "config", "thrustmaster.yaml")
     launch_backend = LaunchConfiguration("launch_backend", default="False")
     launch_backend_cmd = DeclareLaunchArgument(
         "launch_backend",
@@ -34,15 +35,12 @@ def generate_launch_description():
             launch_ros.actions.Node(
                 package="joy", executable="joy_node", name="joystick"
             ),
-            launch_ros.actions.Node(
-                package="drive",
-                executable="joystick_controller",
-                name="joystick_controller",
-                parameters=[
-                    {"linear_axis_index": 1},
-                    {"turn_axis_index": 0},
-                    {"max_linear_speed": 2.0},
-                ],
+            Node(
+                package="joystick_control",
+                executable="flightstick_control",
+                name="flightstick_control",
+                output="screen",
+                parameters=[parameters_file],
             ),
         ]
     )

--- a/src/drive_cpp/include/drive_cpp/TalonDriveController.hpp
+++ b/src/drive_cpp/include/drive_cpp/TalonDriveController.hpp
@@ -84,6 +84,12 @@ class TalonDriveController : public rclcpp::Node {
   bool pubElec_;
 
   /**
+   * @brief Timeout before shutting down motors if no control messages are
+   * received.
+   */
+  double timeout_;
+
+  /**
    * @brief The timestamp of the last control message.
    */
   double lastTimestamp_;

--- a/src/drive_cpp/src/TalonDriveController.cpp
+++ b/src/drive_cpp/src/TalonDriveController.cpp
@@ -28,6 +28,8 @@ TalonDriveController::TalonDriveController() : Node("talonDrive") {
   this->declare_parameter("frequency", 10.0);
   const double frequency =
       std::max(this->get_parameter("frequency").as_double(), 1.0);
+  this->declare_parameter("timeout", 2.0);
+  timeout_ = this->get_parameter("timeout").as_double();
 
   this->declare_parameter(
       "wheels", std::vector<std::string>{"frontRight", "frontLeft", "backRight",
@@ -92,7 +94,7 @@ void TalonDriveController::odom_pub_callback() {
 }
 
 void TalonDriveController::control_timer_callback() {
-  if (this->get_clock()->now().seconds() - lastTimestamp_ > 2) {
+  if (this->get_clock()->now().seconds() - lastTimestamp_ > timeout_) {
     for (auto &wheel : wheels_) {
       wheel.setVelocity(0.0);
     }

--- a/src/joystick_control/CMakeLists.txt
+++ b/src/joystick_control/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 3.5)
-project(drive_cpp)
+project(joystick_control)
 
 # Find the required packages
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
-find_package(ros_phoenix REQUIRED)
+find_package(joy REQUIRED)
 
 # Specify the C++ standard
 set(CMAKE_CXX_STANDARD 14)
@@ -15,19 +15,19 @@ set(CMAKE_CXX_STANDARD 14)
 include_directories(include/${PROJECT_NAME})
 
 # Declare the executables for the nodes
-add_executable(drive_cpp src/TalonDriveController.cpp src/WheelControl.cpp)
+add_executable(flightstick_control src/FlightstickControl.cpp src/DriveMode.cpp )
 
 # Link the dependencies to the executable
-ament_target_dependencies(drive_cpp
+ament_target_dependencies(flightstick_control
   rclcpp
   geometry_msgs
   nav_msgs
-  ros_phoenix
+  joy
 )
 
 # Install the executable
 install(TARGETS
-  drive_cpp
+flightstick_control
   DESTINATION lib/${PROJECT_NAME})
 
 # Install header files

--- a/src/joystick_control/include/joystick_control/DriveMode.hpp
+++ b/src/joystick_control/include/joystick_control/DriveMode.hpp
@@ -29,6 +29,11 @@ class DriveMode : public Mode {
    */
   void processJoystickInput(
       std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) override;
+  /**
+   * @brief Declare the parameters for the mode.
+   * @param node Pointer to the ROS2 node.
+   */
+  static void declareParameters(rclcpp::Node* node);
 
  private:
   /**
@@ -55,11 +60,6 @@ class DriveMode : public Mode {
   void handleVideo(std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) const;
 
   /**
-   * @brief Declares and loads the parameters used by the DriveMode class.
-   */
-  void declare_parameters();
-
-  /**
    * @brief Gets the throttle value from the joystick input.
    *
    * @param joystickMsg A shared pointer to the sensor_msgs::msg::Joy message.
@@ -67,6 +67,8 @@ class DriveMode : public Mode {
    */
   double getThrottleValue(
       std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) const;
+
+  void loadParameters();
 
   // Parameters
   int8_t kForwardAxis;    ///< Axis for forward movement.
@@ -79,13 +81,12 @@ class DriveMode : public Mode {
   int8_t kCruiseControl;  ///< Button for enabling cruise control.
   int8_t kThrottleAxis;   ///< Axis for throttle control.
 
-  double kThrottleMax;      ///< Maximum throttle value from joystick.
-  double kThrottleMin;      ///< Minimum throttle value from joystick.
-  double kMaxLinear;        ///< Maximum linear velocity.
-  double kMaxAngular;       ///< Maximum angular velocity.
-  double kMaxIncrement;     ///< Maximum increment for speed changes.
-  double kMinSpeed;         ///< Minimum speed value.
-  static bool initalized_;  ///< Flag to check mode has been initialized.
+  double kThrottleMax;   ///< Maximum throttle value from joystick.
+  double kThrottleMin;   ///< Minimum throttle value from joystick.
+  double kMaxLinear;     ///< Maximum linear velocity.
+  double kMaxAngular;    ///< Maximum angular velocity.
+  double kMaxIncrement;  ///< Maximum increment for speed changes.
+  double kMinSpeed;      ///< Minimum speed value.
 
   rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr
       twist_pub_;  ///< Publisher for Twist messages.

--- a/src/joystick_control/include/joystick_control/DriveMode.hpp
+++ b/src/joystick_control/include/joystick_control/DriveMode.hpp
@@ -1,0 +1,94 @@
+#ifndef JOYSTICK_CONTROL__DRIVEMODE_HPP_
+#define JOYSTICK_CONTROL__DRIVEMODE_HPP_
+
+#include "Mode.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+/**
+ * @class DriveMode
+ * @brief A class that handles the teleop drive mode of the rover using joystick
+ * input.
+ *
+ * This class inherits from the Mode class and processes joystick input to
+ * control the rover's movement, camera, and video functionalities.
+ */
+class DriveMode : public Mode {
+ public:
+  /**
+   * @brief Constructor for the DriveMode class.
+   *
+   * @param node A pointer to the rclcpp::Node instance.
+   */
+  DriveMode(rclcpp::Node* node);
+  /**
+   * @brief Processes the joystick input.
+   *
+   * @param joystickMsg A shared pointer to the incoming sensor_msgs::msg::Joy
+   * message.
+   */
+  void processJoystickInput(
+      std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) override;
+
+ private:
+  /**
+   * @brief creates and publishes the twist msg based on joystickinput.
+   *
+   * @param joystickMsg A shared pointer to the sensor_msgs::msg::Joy message.
+   */
+  void handleTwist(std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) const;
+
+  /**
+   * @brief Handles the camera control based on joystick input. Not implemented
+   * yet.
+   *
+   * @param joystickMsg A shared pointer to the sensor_msgs::msg::Joy message.
+   */
+  void handleCam(std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) const;
+
+  /**
+   * @brief Handles the video control based on joystick input. Not implemented
+   * yet.
+   *
+   * @param joystickMsg A shared pointer to the sensor_msgs::msg::Joy message.
+   */
+  void handleVideo(std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) const;
+
+  /**
+   * @brief Declares and loads the parameters used by the DriveMode class.
+   */
+  void declare_parameters();
+
+  /**
+   * @brief Gets the throttle value from the joystick input.
+   *
+   * @param joystickMsg A shared pointer to the sensor_msgs::msg::Joy message.
+   * @return The throttle value as a double between 0 and one inclusive.
+   */
+  double getThrottleValue(
+      std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) const;
+
+  // Parameters
+  int8_t kForwardAxis;    ///< Axis for forward movement.
+  int8_t kYawAxis;        ///< Axis for yaw (rotation).
+  int8_t kCamTiltAxis;    ///< Axis for camera tilt.
+  int8_t kCamPanAxis;     ///< Axis for camera pan.
+  int8_t kCamReset;       ///< Button for resetting the camera.
+  int8_t kCamNext;        ///< Button for switching to the next camera.
+  int8_t kCamPrev;        ///< Button for switching to the previous camera.
+  int8_t kCruiseControl;  ///< Button for enabling cruise control.
+  int8_t kThrottleAxis;   ///< Axis for throttle control.
+
+  double kThrottleMax;      ///< Maximum throttle value from joystick.
+  double kThrottleMin;      ///< Minimum throttle value from joystick.
+  double kMaxLinear;        ///< Maximum linear velocity.
+  double kMaxAngular;       ///< Maximum angular velocity.
+  double kMaxIncrement;     ///< Maximum increment for speed changes.
+  double kMinSpeed;         ///< Minimum speed value.
+  static bool initalized_;  ///< Flag to check mode has been initialized.
+
+  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr
+      twist_pub_;  ///< Publisher for Twist messages.
+};
+
+#endif  // JOYSTICK_CONTROL__DRIVEMODE_HPP_

--- a/src/joystick_control/include/joystick_control/FlightstickControl.hpp
+++ b/src/joystick_control/include/joystick_control/FlightstickControl.hpp
@@ -35,6 +35,10 @@ class FlightstickControl : public rclcpp::Node {
   void processJoystick(std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg);
 
  private:
+  /*
+   * @brief Declares parameters for the node and modes.
+   */
+  void declareParameters();
   /**
    * @brief Loads parameters from the parameter server.
    *

--- a/src/joystick_control/include/joystick_control/FlightstickControl.hpp
+++ b/src/joystick_control/include/joystick_control/FlightstickControl.hpp
@@ -1,0 +1,91 @@
+#ifndef FLIGHTSTICK_CONTROL_HPP
+#define FLIGHTSTICK_CONTROL_HPP
+
+#include "DriveMode.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/joy.hpp"
+
+/**
+ * @class FlightstickControl
+ * @brief A class to handle joystick inputs and control modes for the rover.
+ *
+ * The FlightstickControl class subscribes to joystick messages and processes
+ * them to control different modes of the rover, such as driving, arm control,
+ * navigation, and science operations.
+ */
+class FlightstickControl : public rclcpp::Node {
+ public:
+  /**
+   * @brief Constructor for FlightstickControl.
+   *
+   * Initializes the node and sets up the joystick subscription.
+   */
+  FlightstickControl();
+
+  /**
+   * @brief Processes joystick messages.
+   *
+   * This function is called whenever a new joystick message is received. It
+   * processes the joystick inputs and performs actions based on the current
+   * mode.
+   *
+   * @param joystickMsg A shared pointer to the received joystick message.
+   */
+  void processJoystick(std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg);
+
+ private:
+  /**
+   * @brief Loads parameters from the parameter server.
+   *
+   * This function loads configuration parameters such as button mappings from
+   * the parameter server.
+   */
+  void loadParameters();
+
+  /**
+   * @enum ModeType
+   * @brief Enumeration of the different control modes.
+   *
+   * This enumeration defines the different control modes that the rover can be
+   * in.
+   */
+  enum class ModeType { NONE, DRIVE, ARM_IK, ARM_MANUAL, NAV, SCIENCE };
+
+  uint8_t kDriveModeButton;      ///< Button index for drive mode.
+  uint8_t kArmIKModeButton;      ///< Button index for inverse kinematics arm
+                                 ///< control mode.
+  uint8_t kArmManualModeButton;  ///< Button index for manual arm control mode.
+  uint8_t kNavModeButton;        ///< Button index for navigation mode.
+  uint8_t kScienceModeButton;    ///< Button index for science mode.
+
+  ModeType currentMode_;  ///< The current control mode of the rover.
+
+  /**
+   * @brief Checks for mode change based on joystick input.
+   *
+   * This function checks if a mode change is requested based on the joystick
+   * input.
+   *
+   * @param joystickMsg A shared pointer to the received joystick message.
+   * @return True if a mode change is requested, false otherwise.
+   */
+  bool checkForModeChange(std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg);
+
+  /**
+   * @brief Changes the control mode.
+   *
+   * This function changes the control mode of the rover to the specified mode.
+   *
+   * @param mode The new control mode to switch to.
+   * @return True if the mode change was successful, false otherwise.
+   */
+  bool changeMode(ModeType mode);
+
+  rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr
+      joy_sub_;  ///< Subscription to joystick messages.
+
+  std::unique_ptr<Mode> mode_;  ///< Pointer to the current mode object.
+};
+
+#endif  // FLIGHTSTICK_CONTROL_HPP

--- a/src/joystick_control/include/joystick_control/Mode.hpp
+++ b/src/joystick_control/include/joystick_control/Mode.hpp
@@ -1,0 +1,45 @@
+/**
+ * @file Mode.hpp
+ * @brief Defines the Mode class for handling joystick input in different modes.
+ */
+
+#ifndef MODE_HPP
+#define MODE_HPP
+
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/joy.hpp"
+
+/**
+ * @class Mode
+ * @brief Abstract base class for different joystick control modes.
+ */
+class Mode {
+ public:
+  /**
+   * @brief Constructor for the Mode class.
+   * @param name The name of the mode.
+   * @param node Pointer to the ROS2 node.
+   */
+  Mode(std::string name, rclcpp::Node* node) : name_(name), node_(node) {}
+  virtual ~Mode() = default;
+
+  /**
+   * @brief Pure virtual function to process joystick input.
+   * @param joystickMsg Shared pointer to the joystick message.
+   */
+  virtual void processJoystickInput(
+      std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) = 0;
+
+  /**
+   * @brief Get the name of the mode.
+   * @return The name of the mode.
+   */
+  std::string getName() { return name_; }
+
+ protected:
+  std::string name_;  ///< The name of the mode.
+  rclcpp::Node*
+      node_;  ///< Pointer to the ROS2 node used for logging and pubishing.
+};
+
+#endif  // MODE_HPP

--- a/src/joystick_control/include/joystick_control/Mode.hpp
+++ b/src/joystick_control/include/joystick_control/Mode.hpp
@@ -37,9 +37,8 @@ class Mode {
   std::string getName() { return name_; }
 
  protected:
-  std::string name_;  ///< The name of the mode.
-  rclcpp::Node*
-      node_;  ///< Pointer to the ROS2 node used for logging and pubishing.
+  std::string name_;    ///< The name of the mode.
+  rclcpp::Node* node_;  ///< Pointer to the ROS2 node.
 };
 
 #endif  // MODE_HPP

--- a/src/joystick_control/package.xml
+++ b/src/joystick_control/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>joystick_control</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="connor.needham2015@gmail.com">connor</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>ros_phoenix</depend>
+  <depend>interfaces</depend>
+  <depend>joy</depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/joystick_control/src/DriveMode.cpp
+++ b/src/joystick_control/src/DriveMode.cpp
@@ -1,0 +1,104 @@
+#include "DriveMode.hpp"
+
+bool DriveMode::initalized_ = false;
+
+DriveMode::DriveMode(rclcpp::Node* node) : Mode("Drive", node) {
+  RCLCPP_INFO(node_->get_logger(), "Drive Mode");
+  declare_parameters();
+  twist_pub_ =
+      node_->create_publisher<geometry_msgs::msg::Twist>("/cmd_vel", 10);
+  initalized_ = true;
+}
+
+void DriveMode::processJoystickInput(
+    std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) {
+  handleTwist(joystickMsg);
+  handleCam(joystickMsg);
+  handleVideo(joystickMsg);
+}
+
+double DriveMode::getThrottleValue(
+    std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) const {
+  if (kThrottleAxis != -1) {
+    double throttle = joystickMsg->axes[kThrottleAxis];
+    throttle = std::max(kThrottleMin, std::min(kThrottleMax, throttle));
+    // Normalize the throttle value to be between 0 and 1
+    return (throttle - kThrottleMin) / (kThrottleMax - kThrottleMin);
+  }
+  return 1.0;
+}
+
+void DriveMode::handleTwist(
+    std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) const {
+  static double last_forward = 0;
+  double forward, yaw, throttle;
+  throttle = getThrottleValue(joystickMsg);
+  if (joystickMsg->buttons[kCruiseControl] == 1) {
+    forward = last_forward;
+  } else {
+    forward = joystickMsg->axes[kForwardAxis] * throttle * kMaxLinear;
+  }
+  yaw = joystickMsg->axes[kYawAxis] * throttle * kMaxAngular;
+  if (std::abs(forward) < kMinSpeed) {
+    forward = 0;
+  }
+  if (std::abs(yaw) < kMinSpeed) {
+    yaw = 0;
+  }
+  if (forward >= last_forward) {
+    forward = std::min(forward, last_forward + kMaxIncrement);
+  } else {
+    forward = std::max(forward, last_forward - kMaxIncrement);
+  }
+  last_forward = forward;
+  auto twist = geometry_msgs::msg::Twist();
+  twist.linear.x = forward;
+  twist.angular.z = yaw;
+  twist_pub_->publish(twist);
+}
+
+void DriveMode::handleCam(
+    std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) const {
+  // TODO: Implement camera control
+}
+
+void DriveMode::handleVideo(
+    std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) const {
+  // TODO: Implement stream control
+}
+
+void DriveMode::declare_parameters() {
+  if (!initalized_) {
+    node_->declare_parameter("drive_mode.forward_axis", 1);
+    node_->declare_parameter("drive_mode.yaw_axis", 2);
+    node_->declare_parameter("drive_mode.cam_tilt_axis", 3);
+    node_->declare_parameter("drive_mode.cam_pan_axis", 4);
+    node_->declare_parameter("drive_mode.cam_reset", 5);
+    node_->declare_parameter("drive_mode.cam_next", 6);
+    node_->declare_parameter("drive_mode.cam_prev", 7);
+    node_->declare_parameter("drive_mode.cruise_control", 8);
+    node_->declare_parameter("drive_mode.max_linear", 2.0);
+    node_->declare_parameter("drive_mode.max_angular", 2.0);
+    node_->declare_parameter("drive_mode.max_increment", 0.1);
+    node_->declare_parameter("drive_mode.min_speed", 0.1);
+    node_->declare_parameter("drive_mode.throttle.axis", 0);
+    node_->declare_parameter("drive_mode.throttle.max", 1.0);
+    node_->declare_parameter("drive_mode.throttle.min", -1.0);
+  }
+
+  node_->get_parameter("drive_mode.forward_axis", kForwardAxis);
+  node_->get_parameter("drive_mode.yaw_axis", kYawAxis);
+  node_->get_parameter("drive_mode.cam_tilt_axis", kCamTiltAxis);
+  node_->get_parameter("drive_mode.cam_pan_axis", kCamPanAxis);
+  node_->get_parameter("drive_mode.cam_reset", kCamReset);
+  node_->get_parameter("drive_mode.cam_next", kCamNext);
+  node_->get_parameter("drive_mode.cam_prev", kCamPrev);
+  node_->get_parameter("drive_mode.cruise_control", kCruiseControl);
+  node_->get_parameter("drive_mode.max_linear", kMaxLinear);
+  node_->get_parameter("drive_mode.max_angular", kMaxAngular);
+  node_->get_parameter("drive_mode.max_increment", kMaxIncrement);
+  node_->get_parameter("drive_mode.min_speed", kMinSpeed);
+  node_->get_parameter("drive_mode.throttle.axis", kThrottleAxis);
+  node_->get_parameter("drive_mode.throttle.max", kThrottleMax);
+  node_->get_parameter("drive_mode.throttle.min", kThrottleMin);
+}

--- a/src/joystick_control/src/DriveMode.cpp
+++ b/src/joystick_control/src/DriveMode.cpp
@@ -1,13 +1,10 @@
 #include "DriveMode.hpp"
 
-bool DriveMode::initalized_ = false;
-
 DriveMode::DriveMode(rclcpp::Node* node) : Mode("Drive", node) {
   RCLCPP_INFO(node_->get_logger(), "Drive Mode");
-  declare_parameters();
+  loadParameters();
   twist_pub_ =
       node_->create_publisher<geometry_msgs::msg::Twist>("/cmd_vel", 10);
-  initalized_ = true;
 }
 
 void DriveMode::processJoystickInput(
@@ -67,25 +64,25 @@ void DriveMode::handleVideo(
   // TODO: Implement stream control
 }
 
-void DriveMode::declare_parameters() {
-  if (!initalized_) {
-    node_->declare_parameter("drive_mode.forward_axis", 1);
-    node_->declare_parameter("drive_mode.yaw_axis", 2);
-    node_->declare_parameter("drive_mode.cam_tilt_axis", 3);
-    node_->declare_parameter("drive_mode.cam_pan_axis", 4);
-    node_->declare_parameter("drive_mode.cam_reset", 5);
-    node_->declare_parameter("drive_mode.cam_next", 6);
-    node_->declare_parameter("drive_mode.cam_prev", 7);
-    node_->declare_parameter("drive_mode.cruise_control", 8);
-    node_->declare_parameter("drive_mode.max_linear", 2.0);
-    node_->declare_parameter("drive_mode.max_angular", 2.0);
-    node_->declare_parameter("drive_mode.max_increment", 0.1);
-    node_->declare_parameter("drive_mode.min_speed", 0.1);
-    node_->declare_parameter("drive_mode.throttle.axis", 0);
-    node_->declare_parameter("drive_mode.throttle.max", 1.0);
-    node_->declare_parameter("drive_mode.throttle.min", -1.0);
-  }
+void DriveMode::declareParameters(rclcpp::Node* node) {
+  node->declare_parameter("drive_mode.forward_axis", 1);
+  node->declare_parameter("drive_mode.yaw_axis", 2);
+  node->declare_parameter("drive_mode.cam_tilt_axis", 3);
+  node->declare_parameter("drive_mode.cam_pan_axis", 4);
+  node->declare_parameter("drive_mode.cam_reset", 5);
+  node->declare_parameter("drive_mode.cam_next", 6);
+  node->declare_parameter("drive_mode.cam_prev", 7);
+  node->declare_parameter("drive_mode.cruise_control", 8);
+  node->declare_parameter("drive_mode.max_linear", 2.0);
+  node->declare_parameter("drive_mode.max_angular", 2.0);
+  node->declare_parameter("drive_mode.max_increment", 0.1);
+  node->declare_parameter("drive_mode.min_speed", 0.1);
+  node->declare_parameter("drive_mode.throttle.axis", 0);
+  node->declare_parameter("drive_mode.throttle.max", 1.0);
+  node->declare_parameter("drive_mode.throttle.min", -1.0);
+}
 
+void DriveMode::loadParameters() {
   node_->get_parameter("drive_mode.forward_axis", kForwardAxis);
   node_->get_parameter("drive_mode.yaw_axis", kYawAxis);
   node_->get_parameter("drive_mode.cam_tilt_axis", kCamTiltAxis);

--- a/src/joystick_control/src/FlightstickControl.cpp
+++ b/src/joystick_control/src/FlightstickControl.cpp
@@ -1,0 +1,82 @@
+#include "FlightstickControl.hpp"
+
+FlightstickControl::FlightstickControl()
+    : Node("flightstick_control"),
+      mode_(nullptr),
+      currentMode_(ModeType::NONE) {
+  loadParameters();
+  changeMode(currentMode_);
+  joy_sub_ = this->create_subscription<sensor_msgs::msg::Joy>(
+      "/joy", 10,
+      std::bind(&FlightstickControl::processJoystick, this,
+                std::placeholders::_1));
+}
+
+void FlightstickControl::processJoystick(
+    std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) {
+  if (checkForModeChange(joystickMsg)) {
+    return;
+  }
+  if (mode_ != nullptr && currentMode_ != ModeType::NONE) {
+    mode_->processJoystickInput(joystickMsg);
+  }
+}
+
+bool FlightstickControl::checkForModeChange(
+    std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) {
+  if (joystickMsg->buttons[kDriveModeButton]) {
+    return changeMode(ModeType::DRIVE);
+  } else if (joystickMsg->buttons[kArmIKModeButton]) {
+    return changeMode(ModeType::ARM_IK);
+  } else if (joystickMsg->buttons[kArmManualModeButton]) {
+    return changeMode(ModeType::ARM_MANUAL);
+  } else if (joystickMsg->buttons[kNavModeButton]) {
+    return changeMode(ModeType::NAV);
+  } else if (joystickMsg->buttons[kScienceModeButton]) {
+    return changeMode(ModeType::SCIENCE);
+  }
+  return false;
+}
+
+bool FlightstickControl::changeMode(ModeType mode) {
+  if (currentMode_ == mode) {
+    return false;
+  }
+  currentMode_ = mode;
+  switch (mode) {
+    case ModeType::NONE:
+      mode_ = nullptr;
+      return true;
+    case ModeType::DRIVE:
+      RCLCPP_INFO(this->get_logger(), "Entering Drive Mode");
+      mode_ = std::make_unique<DriveMode>(this);
+      return true;
+    default:
+      RCLCPP_WARN(this->get_logger(),
+                  "Mode not implemented, returning to NONE");
+      currentMode_ = ModeType::NONE;
+      mode_ = nullptr;
+      return false;
+  }
+  return false;
+}
+
+void FlightstickControl::loadParameters() {
+  this->declare_parameter("drive_mode_button", 12);
+  this->declare_parameter("arm_ik_mode_button", 11);
+  this->declare_parameter("arm_manual_mode_button", 10);
+  this->declare_parameter("nav_mode_button", 13);
+  this->declare_parameter("science_mode_button", 14);
+  this->get_parameter("drive_mode_button", kDriveModeButton);
+  this->get_parameter("arm_ik_mode_button", kArmIKModeButton);
+  this->get_parameter("arm_manual_mode_button", kArmManualModeButton);
+  this->get_parameter("nav_mode_button", kNavModeButton);
+  this->get_parameter("science_mode_button", kScienceModeButton);
+}
+
+int main(int argc, char **argv) {
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<FlightstickControl>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/joystick_control/src/FlightstickControl.cpp
+++ b/src/joystick_control/src/FlightstickControl.cpp
@@ -61,12 +61,16 @@ bool FlightstickControl::changeMode(ModeType mode) {
   return false;
 }
 
-void FlightstickControl::loadParameters() {
+void FlightstickControl::declareParameters() {
   this->declare_parameter("drive_mode_button", 12);
   this->declare_parameter("arm_ik_mode_button", 11);
   this->declare_parameter("arm_manual_mode_button", 10);
   this->declare_parameter("nav_mode_button", 13);
   this->declare_parameter("science_mode_button", 14);
+  DriveMode::declareParameters(this);
+}
+
+void FlightstickControl::loadParameters() {
   this->get_parameter("drive_mode_button", kDriveModeButton);
   this->get_parameter("arm_ik_mode_button", kArmIKModeButton);
   this->get_parameter("arm_manual_mode_button", kArmManualModeButton);


### PR DESCRIPTION
Flight-stick controller
This PR implements simple drive mechanisms on the rover with a few QOL features (acc limiting, cruise control, ect..).
The beef of the pull request is setting up the ability to further create seperate modes switchable at runtime.

I was thinking the following modes:
1. Stop (soft e-stop)
2. Drive
3. Science control
4. Arm IK
5. Arm Manual
6. Navigation

I also left buttons for the operator to control the camera that could be useful in the future.

Testing has been minor so far and only with the thrustmaster. A new config file for the new flightstick mapping will be needed.