### PR TITLE
Add absolute encoder support

### DIFF
--- a/src/drive/launch/talon.launch.py
+++ b/src/drive/launch/talon.launch.py
@@ -8,11 +8,6 @@ P = 2.00
 I = 0.000002
 D = 0.0000000001
 
-# values for setting input_type
-ANALOG = 1
-ABSOLUTE = 2
-RELATIVE = 3
-
 
 def generate_launch_description():
     """Generate launch description with multiple components."""
@@ -29,13 +24,51 @@ def generate_launch_description():
                 plugin="ros_phoenix::TalonSRX",
                 name="frontLeft",
                 parameters=[
-                    {"id": 8},
+                    {"id": 1},
                     {"P": P},
                     {"I": I},
                     {"D": D},
                     {"max_voltage": 24.0},
                     {"brake_mode": True},
-                    {"input_type": ABSOLUTE},
+                ],
+            ),
+            ComposableNode(
+                package="ros_phoenix",
+                plugin="ros_phoenix::TalonSRX",
+                name="backLeft",
+                parameters=[
+                    {"id": 2},
+                    {"P": P},
+                    {"I": I},
+                    {"D": D},
+                    {"max_voltage": 24.0},
+                    {"brake_mode": True},
+                ],
+            ),
+            ComposableNode(
+                package="ros_phoenix",
+                plugin="ros_phoenix::TalonSRX",
+                name="frontRight",
+                parameters=[
+                    {"id": 3},
+                    {"P": P},
+                    {"I": I},
+                    {"D": D},
+                    {"max_voltage": 24.0},
+                    {"brake_mode": True},
+                ],
+            ),
+            ComposableNode(
+                package="ros_phoenix",
+                plugin="ros_phoenix::TalonSRX",
+                name="backRight",
+                parameters=[
+                    {"id": 4},
+                    {"P": P},
+                    {"I": I},
+                    {"D": D},
+                    {"max_voltage": 24.0},
+                    {"brake_mode": True},
                 ],
             ),
         ],
@@ -50,7 +83,7 @@ def generate_launch_description():
                 executable="drive_cpp",
                 name="talon_control_node",
                 parameters=[
-                    {"wheels": ["frontLeft"]},
+                    {"wheels": ["frontRight", "frontLeft", "backRight", "backLeft"]},
                     {"max_speed": 2.0},
                     {"base_width": 0.9},
                     {"pub_odom": True},

--- a/src/drive/launch/talon.launch.py
+++ b/src/drive/launch/talon.launch.py
@@ -8,6 +8,11 @@ P = 2.00
 I = 0.000002
 D = 0.0000000001
 
+# values for setting input_type
+ANALOG = 1
+ABSOLUTE = 2
+RELATIVE = 3
+
 
 def generate_launch_description():
     """Generate launch description with multiple components."""
@@ -24,51 +29,13 @@ def generate_launch_description():
                 plugin="ros_phoenix::TalonSRX",
                 name="frontLeft",
                 parameters=[
-                    {"id": 1},
+                    {"id": 8},
                     {"P": P},
                     {"I": I},
                     {"D": D},
                     {"max_voltage": 24.0},
                     {"brake_mode": True},
-                ],
-            ),
-            ComposableNode(
-                package="ros_phoenix",
-                plugin="ros_phoenix::TalonSRX",
-                name="backLeft",
-                parameters=[
-                    {"id": 2},
-                    {"P": P},
-                    {"I": I},
-                    {"D": D},
-                    {"max_voltage": 24.0},
-                    {"brake_mode": True},
-                ],
-            ),
-            ComposableNode(
-                package="ros_phoenix",
-                plugin="ros_phoenix::TalonSRX",
-                name="frontRight",
-                parameters=[
-                    {"id": 3},
-                    {"P": P},
-                    {"I": I},
-                    {"D": D},
-                    {"max_voltage": 24.0},
-                    {"brake_mode": True},
-                ],
-            ),
-            ComposableNode(
-                package="ros_phoenix",
-                plugin="ros_phoenix::TalonSRX",
-                name="backRight",
-                parameters=[
-                    {"id": 4},
-                    {"P": P},
-                    {"I": I},
-                    {"D": D},
-                    {"max_voltage": 24.0},
-                    {"brake_mode": True},
+                    {"input_type": ABSOLUTE},
                 ],
             ),
         ],
@@ -83,7 +50,7 @@ def generate_launch_description():
                 executable="drive_cpp",
                 name="talon_control_node",
                 parameters=[
-                    {"wheels": ["frontRight", "frontLeft", "backRight", "backLeft"]},
+                    {"wheels": ["frontLeft"]},
                     {"max_speed": 2.0},
                     {"base_width": 0.9},
                     {"pub_odom": True},

--- a/src/ros_phoenix_humble/include/ros_phoenix/base_node.hpp
+++ b/src/ros_phoenix_humble/include/ros_phoenix/base_node.hpp
@@ -5,6 +5,11 @@
 #include "ros_phoenix/msg/motor_control.hpp"
 #include "ros_phoenix/msg/motor_status.hpp"
 
+//Constants for input_type parameter.
+#define ANALOG 1
+#define ABSOLUTE 2
+#define RELATIVE 3
+
 using namespace rclcpp;
 using namespace ros_phoenix::msg;
 

--- a/src/ros_phoenix_humble/include/ros_phoenix/base_node.hpp
+++ b/src/ros_phoenix_humble/include/ros_phoenix/base_node.hpp
@@ -5,7 +5,7 @@
 #include "ros_phoenix/msg/motor_control.hpp"
 #include "ros_phoenix/msg/motor_status.hpp"
 
-//Constants for input_type parameter.
+// Constants for input_type parameter.
 #define ANALOG 1
 #define ABSOLUTE 2
 #define RELATIVE 3

--- a/src/ros_phoenix_humble/src/base_node.cpp
+++ b/src/ros_phoenix_humble/src/base_node.cpp
@@ -2,6 +2,11 @@
 
 #include "ros_phoenix/phoenix_manager.hpp"
 
+// setting values for input_type parameter
+#define ANALOG 1
+#define ABSOLUTE 2
+#define RELATIVE 3
+
 namespace ros_phoenix {
 
 const std::string BaseNode::Parameter::ID = "id";
@@ -28,7 +33,7 @@ BaseNode::BaseNode(const std::string &name, const rclcpp::NodeOptions &options)
   this->declare_parameter<bool>("invert", false);
   this->declare_parameter<bool>("invert_sensor", false);
   this->declare_parameter<bool>("brake_mode", true);
-  this->declare_parameter<bool>("analog_input", false);
+  this->declare_parameter<int>("input_type", RELATIVE);
   this->declare_parameter<double>("max_voltage", 12);
   this->declare_parameter<double>("max_current", 30);
   this->declare_parameter<double>("sensor_multiplier", 1.0);

--- a/src/ros_phoenix_humble/src/base_node.cpp
+++ b/src/ros_phoenix_humble/src/base_node.cpp
@@ -2,11 +2,6 @@
 
 #include "ros_phoenix/phoenix_manager.hpp"
 
-// setting values for input_type parameter
-#define ANALOG 1
-#define ABSOLUTE 2
-#define RELATIVE 3
-
 namespace ros_phoenix {
 
 const std::string BaseNode::Parameter::ID = "id";

--- a/src/ros_phoenix_humble/src/phoenix_nodes.cpp
+++ b/src/ros_phoenix_humble/src/phoenix_nodes.cpp
@@ -40,12 +40,19 @@ void TalonSRXNode::configure_current_limit(TalonSRXConfiguration &config) {
 }
 
 void TalonSRXNode::configure_sensor() {
-  if (this->get_parameter("analog_input").as_bool())
+  if (this->get_parameter("input_type").as_int() == 1)
     this->controller_->ConfigSelectedFeedbackSensor(
         TalonSRXFeedbackDevice::Analog);
-  else
+  else if (this->get_parameter("input_type").as_int() == 2) {
+    this->controller_->ConfigSelectedFeedbackSensor(
+        TalonSRXFeedbackDevice::CTRE_MagEncoder_Absolute);
+  } else if (this->get_parameter("input_type").as_int() == 3) {
     this->controller_->ConfigSelectedFeedbackSensor(
         TalonSRXFeedbackDevice::CTRE_MagEncoder_Relative);
+  } else {
+    RCLCPP_WARN(this->get_logger(), "%ld is an invalid input_type setting.",
+                this->get_parameter("input_type").as_int());
+  }
 }
 
 double TalonSRXNode::get_output_current() {

--- a/src/ros_phoenix_humble/src/phoenix_nodes.cpp
+++ b/src/ros_phoenix_humble/src/phoenix_nodes.cpp
@@ -1,4 +1,5 @@
 #include "ros_phoenix/phoenix_nodes.hpp"
+
 #include "ros_pheonix/base_node.hpp"
 
 namespace ros_phoenix {

--- a/src/ros_phoenix_humble/src/phoenix_nodes.cpp
+++ b/src/ros_phoenix_humble/src/phoenix_nodes.cpp
@@ -1,4 +1,5 @@
 #include "ros_phoenix/phoenix_nodes.hpp"
+#include "ros_pheonix/base_node.hpp"
 
 namespace ros_phoenix {
 
@@ -40,13 +41,13 @@ void TalonSRXNode::configure_current_limit(TalonSRXConfiguration &config) {
 }
 
 void TalonSRXNode::configure_sensor() {
-  if (this->get_parameter("input_type").as_int() == 1)
+  if (this->get_parameter("input_type").as_int() == ANALOG)
     this->controller_->ConfigSelectedFeedbackSensor(
         TalonSRXFeedbackDevice::Analog);
-  else if (this->get_parameter("input_type").as_int() == 2) {
+  else if (this->get_parameter("input_type").as_int() == ABSOLUTE) {
     this->controller_->ConfigSelectedFeedbackSensor(
         TalonSRXFeedbackDevice::CTRE_MagEncoder_Absolute);
-  } else if (this->get_parameter("input_type").as_int() == 3) {
+  } else if (this->get_parameter("input_type").as_int() == RELATIVE) {
     this->controller_->ConfigSelectedFeedbackSensor(
         TalonSRXFeedbackDevice::CTRE_MagEncoder_Relative);
   } else {


### PR DESCRIPTION
Adds absolute encoder support for the talons, as well as changing the analog_input parameter to an input_type parameter that allows setting one of multiple different input types.