### PR TITLE
Navigation bug fixes

### DIFF
--- a/src/cprt_costmap_plugins/src/gridmap_layer.cpp
+++ b/src/cprt_costmap_plugins/src/gridmap_layer.cpp
@@ -187,6 +187,9 @@ void GridmapLayer::updateCosts(nav2_costmap_2d::Costmap2D& master_grid,
     const grid_map::Index index(*it);
     const float value = gridmap_in_.at(layer_name_, index);
     const auto cost = interpretValue(value);
+    if (cost == NO_INFORMATION) {
+      continue;
+    }
 
     // Convert grid_map index to world coordinates
     grid_map::Position position;

--- a/src/cprt_gridmap_filters/src/PreserveCostInflationFilter.cpp
+++ b/src/cprt_gridmap_filters/src/PreserveCostInflationFilter.cpp
@@ -71,7 +71,7 @@ bool PreserveCostInflationFilter<T>::update(const T &mapIn, T &mapOut) {
     return false;
   }
 
-  mapOut.add(this->outputLayer_, 0.0);
+  mapOut.add(this->outputLayer_);
 
   this->computeWithSimpleSerialMethod(mapIn, mapOut);
 
@@ -116,7 +116,7 @@ void PreserveCostInflationFilter<T>::radialInflateSerial(
     auto &cellValue = mapOut.at(this->outputLayer_, *iterator);
 
     if (!std::isfinite(cellValue)) {
-      continue;
+      cellValue = value;
     }
     cellValue = std::max(cellValue, value);
   }

--- a/src/gps/launch/heading.launch.py
+++ b/src/gps/launch/heading.launch.py
@@ -25,6 +25,7 @@ def generate_launch_description():
                     {"Baudrate": 115200},
                     {"Device": "/dev/ttyUSB0"},
                 ],
+                remappings=[("heading", "gps/heading")],
             ),
         ]
     )

--- a/src/gps/launch/rover.launch.py
+++ b/src/gps/launch/rover.launch.py
@@ -5,7 +5,8 @@ import launch
 import launch_ros.actions
 from ament_index_python.packages import get_package_share_directory
 from launch.substitutions import LaunchConfiguration
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 
 
 def generate_launch_description():
@@ -19,7 +20,10 @@ def generate_launch_description():
     )
     os.system(Rover_heading)
 
-    ublox_remappings = [("fix", "gps/fix"), ("/navheading", "gps/heading")]
+    ublox_remappings = [
+        ("ublox_gps_node/fix", "gps/fix"),
+        ("/navheading", "gps/heading"),
+    ]
 
     ublox_gps_node = launch_ros.actions.Node(
         package="ublox_gps",
@@ -28,5 +32,12 @@ def generate_launch_description():
         remappings=ublox_remappings,
         parameters=[params_file],
     )
+    heading_cmd = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory("gps"), "launch", "heading.launch.py"
+            )
+        )
+    )
 
-    return launch.LaunchDescription([ublox_gps_node])
+    return launch.LaunchDescription([ublox_gps_node, heading_cmd])

--- a/src/localization/config/urdf/spike.urdf.xml
+++ b/src/localization/config/urdf/spike.urdf.xml
@@ -14,7 +14,7 @@
   <joint name="zed_camera_joint" type="fixed">
     <parent link="base_link"/>
     <child link="zed_camera_link"/>
-    <origin xyz="0.49 0.0 0.0 " rpy="0 0.28 0"/>
+    <origin xyz="0.49 0.0 0.0 " rpy="0 0.115 0"/>
   </joint>
 
   <joint name="gps_joint" type="fixed">

--- a/src/localization/launch/gps.launch.py
+++ b/src/localization/launch/gps.launch.py
@@ -24,7 +24,7 @@ def generate_launch_description():
     )
 
     navsat_remappings = [
-        ("imu", "zed/zed_node/imu/data"),
+        ("imu", "gps/heading"),
         ("gps/fix", "gps/fix"),
         ("odometry/filtered", "odometry/filtered/global"),
         ("odometry/gps", "gps/odom"),


### PR DESCRIPTION
This PR fixes 3 bugs:

1. The cost inflation gridmap layer was outputting "Unknown" areas as cost 0. This was creating bad path planning as the rover always though driving out of where it could currently see would be a lower cost solution
2. GPS topic names were mismatched causing the navsat transform node not working. Also it now launches both GPS rover nodes (Heading and position) at once.
3. Zed camera has been giving me better obstical detection at further range with a less extreme downward angle.