### PR TITLE
abstract ticks into HW interface

### DIFF
--- a/src/drive/launch/talon.launch.py
+++ b/src/drive/launch/talon.launch.py
@@ -30,6 +30,7 @@ def generate_launch_description():
                     {"D": D},
                     {"max_voltage": 24.0},
                     {"brake_mode": True},
+                    {"sensor_multiplier": 1 / 2760.0},
                 ],
             ),
             ComposableNode(
@@ -43,6 +44,7 @@ def generate_launch_description():
                     {"D": D},
                     {"max_voltage": 24.0},
                     {"brake_mode": True},
+                    {"sensor_multiplier": 1 / 2760.0},
                 ],
             ),
             ComposableNode(
@@ -56,6 +58,7 @@ def generate_launch_description():
                     {"D": D},
                     {"max_voltage": 24.0},
                     {"brake_mode": True},
+                    {"sensor_multiplier": 1 / 2760.0},
                 ],
             ),
             ComposableNode(
@@ -69,6 +72,7 @@ def generate_launch_description():
                     {"D": D},
                     {"max_voltage": 24.0},
                     {"brake_mode": True},
+                    {"sensor_multiplier": 1 / 2760.0},
                 ],
             ),
         ],

--- a/src/drive_cpp/include/drive_cpp/TalonDriveController.hpp
+++ b/src/drive_cpp/include/drive_cpp/TalonDriveController.hpp
@@ -73,9 +73,9 @@ class TalonDriveController : public rclcpp::Node {
   double linearCov_;
 
   /**
-   * @brief Ticks per meter used for odometry output
+   * @brief Circumference of the wheels, used for computing velocity.
    */
-  double ticksPerMeter_;
+  double wheelCircumference_;
 
   /**
    * @brief Flag indicating whether to publish electrical status


### PR DESCRIPTION
I found the sensor_multiplier while looking at the phoenix system ros2_control HW interface (that we may use for the arm). This completely abstracts the knowlege of ticks into the HW package (phoenix) and allows the controller to work in rotations per second rather than ticks per second.

This change is for abstraction + style only and has no performance / feature benefits so therefore no rush. Let me know your thoughts.