### PR TITLE
fix: typo

### DIFF
--- a/src/ros_phoenix_humble/src/phoenix_nodes.cpp
+++ b/src/ros_phoenix_humble/src/phoenix_nodes.cpp
@@ -1,6 +1,6 @@
 #include "ros_phoenix/phoenix_nodes.hpp"
 
-#include "ros_pheonix/base_node.hpp"
+#include "ros_phoenix/base_node.hpp"
 
 namespace ros_phoenix {
 


### PR DESCRIPTION
Small typo that broke main on the last merge. Planning to YOLO merge due to time the breaking nature of this typo.