### PR TITLE
Use rosdep over script for moveit servo dep

### DIFF
--- a/setup/install_ros_humble.sh
+++ b/setup/install_ros_humble.sh
@@ -57,8 +57,6 @@ pip3 install adafruit-circuitpython-busdevice
 pip3 install adafruit-circuitpython-register
 pip3 install pyubx2
 
-sudo apt install ros-humble-moveit-servo
-
 sudo rosdep init
 rosdep update
 

--- a/src/arm_srdf/package.xml
+++ b/src/arm_srdf/package.xml
@@ -44,6 +44,7 @@
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>warehouse_ros_mongo</exec_depend>
   <exec_depend>xacro</exec_depend>
+  <exec_depend>moveit_servo</exec_depend>
 
 
   <export>


### PR DESCRIPTION
I am trying to use rosdep whenever possible over first time install scripts. Better for those few poor soles who are trying to run it on non ubuntu hosts. Also please add the -y flag for any apt installs that are necessary since we don't want to have to accept each install.