### PR TITLE
feat: implement angular slip ratio for driving

### DIFF
--- a/src/drive/launch/talon.launch.py
+++ b/src/drive/launch/talon.launch.py
@@ -95,6 +95,7 @@ def generate_launch_description():
                     {"pub_odom": True},
                     {"pub_elec": True},
                     {"wheel_rad": 0.10},
+                    {"angular_slip_ratio": 0.8},
                 ],
             ),
         ]

--- a/src/drive_cpp/include/drive_cpp/TalonDriveController.hpp
+++ b/src/drive_cpp/include/drive_cpp/TalonDriveController.hpp
@@ -78,6 +78,12 @@ class TalonDriveController : public rclcpp::Node {
   double wheelCircumference_;
 
   /**
+   * @brief Ratio of expected slip on angular movement (must be > 0 and <=1)
+   * ~0 means can not turn, 1 means no slip
+   */
+  double angularSlipRatio_;
+
+  /**
    * @brief Flag indicating whether to publish electrical status
    * information. (Not implemented)
    */


### PR DESCRIPTION
This is something I was playing around with for helping with autonomous navigation since following the path closesly required compensating for some slip. After URC 0.5 we decided that it would be useful for teleop as well so I cherry picked the commit into it's own branch for a PR.

I choose to implement this in the diff drive controller rather than the joystick or nav2 controller server since it should be useful (and the same) for both.

As a parameter in the launch file we can change without rebuilding in the feild. 