### PR TITLE
fix: ownership of symbolic link

### DIFF
--- a/setup/setup_service.sh
+++ b/setup/setup_service.sh
@@ -17,6 +17,7 @@ sudo ln -s $PWD/start_rover.sh /usr/local/bin/start_rover.sh
 
 cd ..
 sudo ln -s $PWD/install/setup.bash /opt/ros/humble/cprt_setup.bash
+sudo chown $CURRENT_USER /opt/ros/humble/cprt_setup.bash
 
 sudo systemctl daemon-reload
 sudo systemctl enable start_rover.service


### PR DESCRIPTION
The root ownership of the symbolic link of the install/setup.bash file was causing issues in sourcing it withing the service file. It is now working correctly.