### PR TITLE
fix: startup sourcing

### DIFF
--- a/setup/setup_service.sh
+++ b/setup/setup_service.sh
@@ -16,7 +16,10 @@ sudo chmod 644 /etc/systemd/system/start_rover.service
 sudo ln -s $PWD/start_rover.sh /usr/local/bin/start_rover.sh
 
 cd ..
-sudo ln -s $PWD/install/setup.bash /opt/ros/humble/cprt_setup.bash
+sudo tee /opt/ros/humble/cprt_setup.bash > /dev/null << EOF
+#!/bin/bash
+source $PWD/install/setup.bash
+EOF
 
 sudo systemctl daemon-reload
 sudo systemctl enable start_rover.service

--- a/setup/start_rover.sh
+++ b/setup/start_rover.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-
+source ~/gstreamer/setupGstreamer.sh
 source /opt/ros/humble/setup.bash
 source /opt/ros/humble/cprt_setup.bash
-source ~/.bashrc
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 ros2 launch rosbridge_server rosbridge_websocket_launch.xml


### PR DESCRIPTION
The install/setup.bash uses it's location relative to the other directories in the install dir. When we use a symbolic link we break that. I am getting around that by creating a small new script.

Tested and it seems to work.