### PR TITLE
Velocity Control IK

### DIFF
--- a/src/arm_srdf/config/arm_config.yaml
+++ b/src/arm_srdf/config/arm_config.yaml
@@ -19,15 +19,15 @@ scale:
   linear:  0.8  # Max linear velocity. Unit is [m/s]. Only used for Cartesian commands.
   rotational:  0.8  # Max angular velocity. Unit is [rad/s]. Only used for Cartesian commands.
   # Max joint angular/linear velocity. Only used for joint commands on joint_command_in_topic.
-  joint: 0.5
+  joint: 2.0
 
 # What type of topic does your robot driver expect?
 # Currently supported are std_msgs/Float64MultiArray or trajectory_msgs/JointTrajectory
-command_out_type: trajectory_msgs/JointTrajectory
+command_out_type: std_msgs/Float64MultiArray
 
 # What to publish? Can save some bandwidth as most robots only require positions or velocities
-publish_joint_positions: true
-publish_joint_velocities: false
+publish_joint_positions: false
+publish_joint_velocities: true
 publish_joint_accelerations: false
 
 #low_pass_filter_coeff: 2.0
@@ -45,33 +45,35 @@ check_octomap_collisions: false  # Check collision against the octomap (if a 3D 
 ## MoveIt properties
 move_group_name: rover_arm  # Often 'manipulator' or 'arm'
 planning_frame: Link_1
-ee_frame_name: Link_7
+ee_frame_name: eef_link
 robot_link_command_frame: Link_1
 
 ## Stopping behaviour
-incoming_command_timeout:  0.1  # Stop servoing if X seconds elapse without a new command
+incoming_command_timeout:  0.2  # Stop servoing if X seconds elapse without a new command
 # If 0, republish commands forever even if the robot is stationary. Otherwise, specify num. to publish.
 # Important because ROS may drop some messages and we need the robot to halt reliably.
 num_outgoing_halt_msgs_to_publish: 0
+halt_all_joints_in_joint_mode: false
+halt_all_joints_in_cartesian_mode: false
 
 ## Configure handling of singularities and joint limits
-lower_singularity_threshold: 17.0  # Start decelerating when the condition number hits this (close to singularity)
+lower_singularity_threshold: 10.0  # Start decelerating when the condition number hits this (close to singularity)
 hard_stop_singularity_threshold: 30.0  # Stop when the condition number hits this
-leaving_singularity_threshold_multiplier: 2.0  # Multiply the hard stop limit by this when leaving singularity (see https://github.com/moveit/moveit2/pull/620)
+leaving_singularity_threshold_multiplier: 5.0  # Multiply the hard stop limit by this when leaving singularity (see https://github.com/moveit/moveit2/pull/620)
 # Added as a buffer to joint variable position bounds [in that joint variable's respective units].
 # Can be of size 1, which applies the margin to all joints, or the same size as the number of degrees of freedom of the active joint group.
 # If moving quickly, make these values larger.
-#joint_limit_margins: [0.12]
+joint_limit_margin: 0.001
 
 ## Topic names
 cartesian_command_in_topic: ~/delta_twist_cmds  # Topic for incoming Cartesian twist commands
 joint_command_in_topic: ~/delta_joint_cmds  # Topic for incoming joint angle commands
 joint_topic: /joint_states  # Get joint states from this tpoic
 status_topic: ~/status  # Publish status to this topic
-command_out_topic: /rover_arm_controller/joint_trajectory  # Publish outgoing commands here
+command_out_topic: /rover_arm_controller/commands  # Publish outgoing commands here
 
 ## Collision checking for the entire robot body
-check_collisions: true  # Check collisions?
+check_collisions: false  # Check collisions?
 collision_check_rate: 10.0  # [Hz] Collision-checking can easily bog down a CPU if done too often.
 self_collision_proximity_threshold: 0.01  # Start decelerating when a self-collision is this far [m]
 scene_collision_proximity_threshold: 0.02  # Start decelerating when a scene collision is this far [m]

--- a/src/arm_srdf/config/arm_urdf.ros2_control.xacro
+++ b/src/arm_srdf/config/arm_urdf.ros2_control.xacro
@@ -1,63 +1,48 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-    <xacro:macro name="arm_urdf_ros2_control" params="name initial_positions_file">
-        <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_positions']}"/>
-
-        <ros2_control name="${name}" type="system">
-            <hardware>
-                <!-- By default, set up controllers for simulation. This won't work on real hardware -->
-                <!--<plugin>mock_components/GenericSystem</plugin> !-->
-                <plugin>ros2_control_rover_arm/RoverArmHardwareInterface</plugin>
-            </hardware>
-            <joint name="Joint_1">
-                <command_interface name="position"/>
-                <command_interface name="velocity"/>
-                <state_interface name="position">
-                  <param name="initial_value">${initial_positions['Joint_1']}</param>
-                </state_interface>
-                <state_interface name="velocity"/>
-            </joint>
-            <joint name="Joint_2">
-                <command_interface name="position"/>
-                <command_interface name="velocity"/>
-                <state_interface name="position">
-                  <param name="initial_value">${initial_positions['Joint_2']}</param>
-                </state_interface>
-                <state_interface name="velocity"/>
-            </joint>
-            <joint name="Joint_3">
-                <command_interface name="position"/>
-                <command_interface name="velocity"/>
-                <state_interface name="position">
-                  <param name="initial_value">${initial_positions['Joint_3']}</param>
-                </state_interface>
-                <state_interface name="velocity"/>
-            </joint>
-            <joint name="Joint_4">
-                <command_interface name="position"/>
-                <command_interface name="velocity"/>
-                <state_interface name="position">
-                  <param name="initial_value">${initial_positions['Joint_4']}</param>
-                </state_interface>
-                <state_interface name="velocity"/>
-            </joint>
-            <joint name="Joint_5">
-                <command_interface name="position"/>
-                <command_interface name="velocity"/>
-                <state_interface name="position">
-                  <param name="initial_value">${initial_positions['Joint_5']}</param>
-                </state_interface>
-                <state_interface name="velocity"/>
-            </joint>
-            <joint name="Joint_6">
-                <command_interface name="position"/>
-                <command_interface name="velocity"/>
-                <state_interface name="position">
-                  <param name="initial_value">${initial_positions['Joint_6']}</param>
-                </state_interface>
-                <state_interface name="velocity"/>
-            </joint>
-
-        </ros2_control>
-    </xacro:macro>
+  <xacro:macro name="arm_urdf_ros2_control" params="name">
+    <ros2_control name="${name}" type="system">
+      <hardware>
+        <!-- By default, set up controllers for simulation. This won't work on real hardware -->
+        <!--<plugin>mock_components/GenericSystem</plugin> !-->
+        <plugin>ros2_control_rover_arm/RoverArmHardwareInterface</plugin>
+      </hardware>
+      <joint name="Joint_1">
+        <param name="node_name">base</param>
+        <command_interface name="velocity"/>
+        <state_interface name="position"/>
+        <state_interface name="velocity"/>
+      </joint>
+      <joint name="Joint_2">
+        <param name="node_name">act1</param>
+        <command_interface name="velocity"/>
+        <state_interface name="position"/>
+        <state_interface name="velocity"/>
+      </joint>
+      <joint name="Joint_3">
+        <param name="node_name">act2</param>
+        <command_interface name="velocity"/>
+        <state_interface name="position"/>
+        <state_interface name="velocity"/>
+      </joint>
+      <joint name="Joint_4">
+        <param name="node_name">elbow</param>
+        <command_interface name="velocity"/>
+        <state_interface name="position"/>
+        <state_interface name="velocity"/>
+      </joint>
+      <joint name="Joint_5">
+        <param name="node_name">wristTilt</param>
+        <command_interface name="velocity"/>
+        <state_interface name="position"/>
+        <state_interface name="velocity"/>
+      </joint>
+      <joint name="Joint_6">
+        <param name="node_name">wristTurn</param>
+        <command_interface name="velocity"/>
+        <state_interface name="position"/>
+        <state_interface name="velocity"/>
+      </joint>
+    </ros2_control>
+  </xacro:macro>
 </robot>

--- a/src/arm_srdf/config/arm_urdf.urdf.xacro
+++ b/src/arm_srdf/config/arm_urdf.urdf.xacro
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="arm_urdf">
-    <xacro:arg name="initial_positions_file" default="initial_positions.yaml" />
 
     <!-- Import arm_urdf urdf file -->
     <xacro:include filename="$(find arm_urdf)/urdf/arm_urdf.urdf" />
@@ -9,6 +8,6 @@
     <xacro:include filename="arm_urdf.ros2_control.xacro" />
 
 
-    <xacro:arm_urdf_ros2_control name="FakeSystem" initial_positions_file="$(arg initial_positions_file)"/>
+    <xacro:arm_urdf_ros2_control name="ArmSystem"/>
 
 </robot>

--- a/src/arm_srdf/config/joint_limits.yaml
+++ b/src/arm_srdf/config/joint_limits.yaml
@@ -9,8 +9,8 @@ default_acceleration_scaling_factor: 1.0
 # Joint limits can be turned off with [has_velocity_limits, has_acceleration_limits]
 joint_limits:
   Joint_1:
-    has_velocity_limits: false
-    max_velocity: 0
+    has_velocity_limits: true
+    max_velocity: 1.0
     has_acceleration_limits: false
     max_acceleration: 0
     has_position_limits: true
@@ -18,12 +18,12 @@ joint_limits:
     min_position: -1.57
   Joint_2:
     has_velocity_limits: true
-    max_velocity: 0.0234 #Takes 23.5 seconds to rotate 45 degrees - roughly 0.0334 rad/s, but set at 0.0234 to account for the cosine nature of lin act joint speeds
+    max_velocity: 0.8
     has_acceleration_limits: false
     max_acceleration: 0
   Joint_3:
     has_velocity_limits: true
-    max_velocity: 0.03688 #Takes 13.8 seconds to go 45 degrees
+    max_velocity: 0.8
     has_acceleration_limits: false
     max_acceleration: 0
   Joint_4:

--- a/src/arm_srdf/config/kinematics.yaml
+++ b/src/arm_srdf/config/kinematics.yaml
@@ -1,7 +1,3 @@
-rover)arn:
-  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
-  kinematics_solver_search_resolution: 0.0050000000000000001
-  kinematics_solver_timeout: 0.0050000000000000001
 rover_arm:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.0050000000000000001

--- a/src/arm_srdf/config/ros2_controllers.yaml
+++ b/src/arm_srdf/config/ros2_controllers.yaml
@@ -4,7 +4,7 @@ controller_manager:
     update_rate: 100  # Hz
 
     rover_arm_controller:
-      type: joint_trajectory_controller/JointTrajectoryController
+      type: velocity_controllers/JointGroupVelocityController
 
 
     joint_state_broadcaster:
@@ -20,7 +20,6 @@ rover_arm_controller:
       - Joint_5
       - Joint_6
     command_interfaces:
-      - position
       - velocity
     state_interfaces:
       - position

--- a/src/arm_srdf/launch/servo.launch.py
+++ b/src/arm_srdf/launch/servo.launch.py
@@ -72,7 +72,7 @@ def test_launch(moveit_config, launch_package_path=None):
             description="By default, we are not in debug mode",
         )
     )
-    ld.add_action(DeclareBooleanLaunchArg("use_rviz", default_value=True))
+    ld.add_action(DeclareBooleanLaunchArg("use_rviz", default_value=False))
     # If there are virtual joints, broadcast static tf by including virtual_joints launch
     virtual_joints_launch = (
         launch_package_path / "launch/static_virtual_joint_tfs.launch.py"
@@ -112,7 +112,6 @@ def test_launch(moveit_config, launch_package_path=None):
         )
     )
 
-    # Fake joint driver
     ld.add_action(
         Node(
             package="controller_manager",
@@ -148,12 +147,13 @@ def test_launch(moveit_config, launch_package_path=None):
             # Assuming ROS2 intraprocess communications works well, this is a more efficient way.
             # ComposableNode(
             #     package="moveit_servo",
-            #     plugin="moveit_servo::ServoServer",
+            #     plugin="moveit_servo::ServoNode",
             #     name="servo_server",
             #     parameters=[
             #         servo_params,
             #         moveit_config.robot_description,
             #         moveit_config.robot_description_semantic,
+            #         moveit_config.robot_description_kinematics,
             #     ],
             # ),
             ComposableNode(
@@ -161,17 +161,6 @@ def test_launch(moveit_config, launch_package_path=None):
                 plugin="robot_state_publisher::RobotStatePublisher",
                 name="robot_state_publisher",
                 parameters=[moveit_config.robot_description],
-            ),
-            ComposableNode(
-                package="tf2_ros",
-                plugin="tf2_ros::StaticTransformBroadcasterNode",
-                name="static_tf2_broadcaster",
-                parameters=[{"child_frame_id": "/Link_7", "frame_id": "/Link_1"}],
-            ),
-            ComposableNode(
-                package="joy",
-                plugin="joy::Joy",
-                name="joy_node",
             ),
         ],
         output="screen",

--- a/src/arm_srdf/launch/talon.launch.py
+++ b/src/arm_srdf/launch/talon.launch.py
@@ -2,6 +2,10 @@ import launch
 import launch_ros.actions
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
+from math import pi
+
+
+PUBLISH_PERIOD = 1
 
 
 def generate_launch_description():
@@ -18,30 +22,69 @@ def generate_launch_description():
                 package="ros_phoenix",
                 plugin="ros_phoenix::TalonSRX",
                 name="base",
-                parameters=[{"id": 10}, {"P": 2.0}, {"I": 0.0}, {"D": 1.0}],
+                parameters=[
+                    {"id": 10},
+                    {"P": 50.0},
+                    {"I": 0.0},
+                    {"D": 1.0},
+                    {"sensor_multiplier": (2 * pi / 4096)},
+                    {"sensor_offset": 1.29444806951},
+                    {"input_type": 2},
+                    {"max_voltage": 6.0},
+                    {"period_ms": PUBLISH_PERIOD},
+                    {"non_continuous": True},
+                ],
             ),
             ComposableNode(
                 package="ros_phoenix",
                 plugin="ros_phoenix::TalonSRX",
                 name="act1",
-                parameters=[{"id": 11}, {"P": 50.0}, {"I": 0.0}, {"D": 0.0}],
+                parameters=[
+                    {"id": 11},
+                    {"P": 110.0},
+                    {"I": 0.0},
+                    {"D": 0.0},
+                    {"input_type": 2},
+                    {"invert_sensor": True},
+                    {"sensor_multiplier": (2 * pi / 4096)},
+                    {"sensor_offset": -0.717016899},
+                    {"max_voltage": 22.0},
+                    {"period_ms": PUBLISH_PERIOD},
+                    {"non_continuous": True},
+                ],
             ),
             ComposableNode(
                 package="ros_phoenix",
                 plugin="ros_phoenix::TalonSRX",
                 name="act2",
-                parameters=[{"id": 12}, {"P": 50.0}, {"I": 0.0}, {"D": 0.0}],
+                parameters=[
+                    {"id": 14},
+                    {"P": 110.0},
+                    {"I": 0.0},
+                    {"D": 0.0},
+                    {"input_type": 2},
+                    {"invert": True},
+                    {"sensor_multiplier": (2 * pi / 4096)},
+                    {"sensor_offset": -2.02401481},
+                    {"max_voltage": 22.0},
+                    {"period_ms": PUBLISH_PERIOD},
+                    {"non_continuous": True},
+                ],
             ),
             ComposableNode(
                 package="ros_phoenix",
                 plugin="ros_phoenix::TalonSRX",
                 name="elbow",
                 parameters=[
-                    {"id": 13},
-                    {"P": 1.0},
+                    {"id": 15},
+                    {"P": 4.0},
                     {"I": 0.0},
                     {"D": 0.0},
-                    {"invert_sensor": True},
+                    {"max_voltage": 22.0},
+                    {"sensor_multiplier": (2 * pi / 4096)},
+                    {"sensor_offset": 0.728687514},
+                    {"input_type": 2},
+                    {"period_ms": PUBLISH_PERIOD},
                 ],
             ),
             ComposableNode(
@@ -49,11 +92,19 @@ def generate_launch_description():
                 plugin="ros_phoenix::TalonSRX",
                 name="wristTilt",
                 parameters=[
-                    {"id": 14},
-                    {"P": 1.5},
+                    {"id": 12},
+                    {"P": 20.0},
                     {"I": 0.0},
-                    {"D": 1.0},
-                    {"max_voltage": 6.0},
+                    {"D": 0.0},
+                    {"max_voltage": 22.0},
+                    {"sensor_multiplier": (2 * pi / 4096)},
+                    {"sensor_offset": 1.25230542},
+                    {"input_type": 2},
+                    {"invert_sensor": True},
+                    {"invert": True},
+                    {"period_ms": PUBLISH_PERIOD},
+                    {"max_voltage": 22.0},
+                    {"non_continuous": True},
                 ],
             ),
             ComposableNode(
@@ -61,12 +112,17 @@ def generate_launch_description():
                 plugin="ros_phoenix::TalonSRX",
                 name="wristTurn",
                 parameters=[
-                    {"id": 15},
-                    {"P": 1.5},
+                    {"id": 13},
+                    {"P": 0.008},
                     {"I": 0.0},
-                    {"D": 1.0},
-                    {"max_voltage": 6.0},
+                    {"D": 0.0},
+                    {"invert": True},
                     {"invert_sensor": True},
+                    {
+                        "sensor_multiplier": 0.00000315420949
+                    },  # 2pi/(WRISTTURN_GEARBOX * WRISTTURN_GEAR)
+                    {"period_ms": PUBLISH_PERIOD},
+                    {"max_voltage": 22.0},
                 ],
             ),
         ],

--- a/src/arm_srdf/launch/talon.launch.py
+++ b/src/arm_srdf/launch/talon.launch.py
@@ -103,7 +103,6 @@ def generate_launch_description():
                     {"invert_sensor": True},
                     {"invert": True},
                     {"period_ms": PUBLISH_PERIOD},
-                    {"max_voltage": 22.0},
                     {"non_continuous": True},
                 ],
             ),

--- a/src/arm_srdf/package.xml
+++ b/src/arm_srdf/package.xml
@@ -36,14 +36,15 @@
   <exec_depend>moveit_ros_move_group</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
   <exec_depend>moveit_ros_warehouse</exec_depend>
+  <exec_depend>moveit_servo</exec_depend>
   <exec_depend>moveit_setup_assistant</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>rviz_common</exec_depend>
   <exec_depend>rviz_default_plugins</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>warehouse_ros_mongo</exec_depend>
-  <exec_depend>xacro</exec_depend>
+  <exec_depend>warehouse_ros</exec_depend>
+  <exec_depend>ros_phoenix</exec_depend>
 
 
   <export>

--- a/src/arm_urdf/urdf/arm_urdf.urdf
+++ b/src/arm_urdf/urdf/arm_urdf.urdf
@@ -4,6 +4,12 @@
      For more information, please see http://wiki.ros.org/sw_urdf_exporter -->
 <robot
   name="arm_urdf">
+  <link name="arm_base_link"/>
+  <joint name="arm_base_joint" type="fixed">
+    <parent link="arm_base_link"/>
+    <child link="Link_1"/>
+    <origin xyz="0.0 0.0 0.0 " rpy="0 0 0"/>
+  </joint>
   <link
     name="Link_1">
     <inertial>
@@ -150,7 +156,7 @@
       link="Link_3" />
     <axis
       xyz="0 -1 0" />
-    <limit effort="100.0" velocity="0.0234" lower="-0.55" upper="0.3236"/>
+    <limit effort="100.0" velocity="0.08" lower="-0.488692" upper="0.279253"/>
   </joint>
   <link
     name="Link_4">
@@ -204,7 +210,7 @@
       link="Link_4" />
     <axis
       xyz="0 -1 0" />
-    <limit effort="100.0" velocity="0.03688" lower="-0.9032" upper="0.054"/>
+    <limit effort="100.0" velocity="0.08" lower="-1.2" upper="0.15"/>
   </joint>
   <link
     name="Link_5">
@@ -258,7 +264,7 @@
       link="Link_5" />
     <axis
       xyz="-0.99059 0 0.1369" />
-    <limit effort="100.0" velocity="0.03688" lower="-3.14" upper="3.14"/>
+    <limit effort="100.0" velocity="1.0" lower="-3.14" upper="3.14"/>
   </joint>
   <link
     name="Link_6">
@@ -356,7 +362,7 @@
   </link>
   <joint
     name="Joint_6"
-    type="revolute">
+    type="continuous">
     <origin
       xyz="0.071675 -0.02785 0"
       rpy="0 0 0" />
@@ -366,6 +372,12 @@
       link="Link_7" />
     <axis
       xyz="-1 0 0" />
-    <limit effort="100.0" velocity="1.0" lower="-3.14" upper="3.14"/>
+    <limit effort="100.0" velocity="1.5"/>
+  </joint>
+  <link name="eef_link"/>
+  <joint name="eef_joint" type="fixed">
+    <parent link="Link_7"/>
+    <child link="eef_link"/>
+    <origin xyz="0.2 0.0 0.0 " rpy="0 0 0"/>
   </joint>
 </robot>

--- a/src/drive/config/pxn.yaml
+++ b/src/drive/config/pxn.yaml
@@ -31,7 +31,7 @@ flightstick_control:
         max: 1.0
       base_axis: 0
       wrist_roll: 4
-      wrist_yaw_positive: 4
+      wrist_yaw_positive: 3
       wrist_yaw_negative: 5
       act1_axis: 1
       act2_axis: 5
@@ -41,3 +41,16 @@ flightstick_control:
       simple_forward: 2
       simple_backward: 3
       servo_port: 0
+  
+    arm_ik_mode:
+      x_axis: 1
+      y_axis: 0
+      up_button: 5
+      down_button: 3
+      rotate_around_y: 5
+      rotate_around_x: 4
+      rotate_around_z: 3
+      open_claw: 0
+      close_claw: 1
+      base_frame: 4
+      eef_frame: 2

--- a/src/drive/launch/flightstick_drive.launch.py
+++ b/src/drive/launch/flightstick_drive.launch.py
@@ -13,7 +13,7 @@ from launch.conditions import IfCondition
 def generate_launch_description():
     """Generate launch description with multiple components."""
     pkg_drive = get_package_share_directory("drive")
-    pkg_arm = get_package_share_directory("arm_interface")
+    pkg_arm = get_package_share_directory("arm_srdf")
     parameters_file = os.path.join(pkg_drive, "config", "pxn.yaml")
     launch_backend = LaunchConfiguration("launch_backend", default="False")
     launch_backend_cmd = DeclareLaunchArgument(

--- a/src/hardware/CMakeLists.txt
+++ b/src/hardware/CMakeLists.txt
@@ -13,6 +13,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp_lifecycle
   interfaces
   ros_phoenix
+  std_srvs
 )
 
 # find dependencies

--- a/src/hardware/package.xml
+++ b/src/hardware/package.xml
@@ -18,7 +18,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>interfaces</depend>
-  <depend>ros_phoenix></depend>
+  <depend>ros_phoenix</depend>
 
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>

--- a/src/hardware/src/rover_arm.cpp
+++ b/src/hardware/src/rover_arm.cpp
@@ -24,7 +24,7 @@ hardware_interface::CallbackReturn RoverArmHardwareInterface::on_init(
     }
     if (node_name.empty()) {
       RCLCPP_FATAL(rclcpp::get_logger("RoverArmHardwareInterface"),
-                   "Missing necessary paramater node_name for joint %s",
+                   "Missing necessary parameter node_name for joint %s",
                    joint.name.c_str());
       return hardware_interface::CallbackReturn::ERROR;
     }

--- a/src/hardware/src/rover_arm.h
+++ b/src/hardware/src/rover_arm.h
@@ -15,52 +15,14 @@
 #include "hardware_interface/system_interface.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
-#include "interfaces/srv/arm_cmd.hpp"
-#include "interfaces/srv/arm_pos.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 #include "rclcpp_lifecycle/state.hpp"
 #include "ros_phoenix/msg/motor_control.hpp"
 #include "ros_phoenix/msg/motor_status.hpp"
-#include "std_msgs/msg/bool.hpp"
-
-#define BASE_BIG_GEAR 100.0
-#define BASE_SMALL_GEAR 15.0
-#define BASE_GEARBOX 1100
-#define ACT1_URDF_OFFSET 0.872665  // thanks alot ivan >:((
-#define ACT1_SIDE_A 20.0
-#define ACT1_SIDE_B 49.544
-#define ACT1_SHAFT_LENGTH 15.24
-#define ACT1_SHAFT_TICKS 5709.0
-#define ACT_LENGTH 30.96
-#define ACT1_DIRECTION 1
-#define ACT2_URDF_OFFSET -0.663225
-#define ACT2_SIDE_A 15.0
-#define ACT2_SIDE_B 42.053
-#define ACT2_SHAFT_LENGTH 13.64
-#define ACT2_SHAFT_TICKS 5109.0
-#define ACT2_DIRECTION -1
-#define ELBOW_SMALL_GEAR 30.0
-#define ELBOW_BIG_GEAR 96.0
-#define ELBOW_GEARBOX 10000.0
-#define WRISTTILT_GEARBOX \
-  7760215.0  // I'm confident that nobody knows what the ratios are for this
-             // gearbox
-#define WRISTTILT_URDF_OFFSET 0.137357412
-#define WRISTTURN_GEAR 498.0
-#define WRISTTURN_GEARBOX 4000.0
+#include "std_srvs/srv/set_bool.hpp"
 
 using namespace std::chrono_literals;
-
-struct EncoderTopic {
-  std::string name;
-  std::function<void(const ros_phoenix::msg::MotorStatus &)> callback;
-};
-
-struct PublisherTopic {
-  std::string name;
-  std::function<double(double)> gear_ratio;
-};
 
 namespace ros2_control_rover_arm {
 class RoverArmHardwareInterface : public hardware_interface::SystemInterface {
@@ -100,83 +62,31 @@ class RoverArmHardwareInterface : public hardware_interface::SystemInterface {
   // hardware commands vector and send it out
   hardware_interface::return_type write(
       const rclcpp::Time &time, const rclcpp::Duration &period) override;
+  // TODO Docs CN
+  static std::string phoenix_to_HW_type(int control_type);
 
  private:
   // Store the command for the simulated robot
-  std::vector<double> hw_commands_;
+  std::vector<std::string> node_names_;
+  std::vector<double> hw_position_commands_;
   std::vector<double> hw_position_states_;
   std::vector<double> hw_velocity_states_;
-  std::vector<double> hw_velocity_commands_;
   std::vector<double> temp_;
+  std::vector<int> control_type_;
+
+  bool open_loop_ = false;
 
   // handling publisher and subscriber callbacks
   rclcpp::Node::SharedPtr node_ptr_;
   rclcpp::Executor::SharedPtr executor_ptr_;
   std::thread executor_thread_;
 
-  void base_callback(const ros_phoenix::msg::MotorStatus &motorStatus);
-  void act1_callback(const ros_phoenix::msg::MotorStatus &motorStatus);
-  void act2_callback(const ros_phoenix::msg::MotorStatus &motorStatus);
-  void elbow_callback(const ros_phoenix::msg::MotorStatus &motorStatus);
-  void wrist_tilt_callback(const ros_phoenix::msg::MotorStatus &motorStatus);
-  void wrist_turn_callback(const ros_phoenix::msg::MotorStatus &motorStatus);
-
-  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr encoder_subscriber_;
-  void encoder_callback(const std_msgs::msg::Bool &encoderPassthrough);
-
-  std::vector<EncoderTopic> subscription_topics_ = {
-      {"base/status", std::bind(&RoverArmHardwareInterface::base_callback, this,
-                                std::placeholders::_1)},
-      {"act1/status", std::bind(&RoverArmHardwareInterface::act1_callback, this,
-                                std::placeholders::_1)},
-      {"act2/status", std::bind(&RoverArmHardwareInterface::act2_callback, this,
-                                std::placeholders::_1)},
-      {"elbow/status", std::bind(&RoverArmHardwareInterface::elbow_callback,
-                                 this, std::placeholders::_1)},
-      {"wristTilt/status",
-       std::bind(&RoverArmHardwareInterface::wrist_tilt_callback, this,
-                 std::placeholders::_1)},
-      {"wristTurn/status",
-       std::bind(&RoverArmHardwareInterface::wrist_turn_callback, this,
-                 std::placeholders::_1)},
-  };
-
-  double base_pos(double rad);
-  double act1_pos(double rad);
-  double act2_pos(double rad);
-  double elbow_pos(double rad);
-  double wrist_tilt_pos(double rad);
-  double wrist_turn_pos(double rad);
-
-  double act_pos(double rad, double a, double b, double urdf_offset,
-                 double shaft_length, double shaft_ticks, double act_length);
-  double act_rad(double pos, double a, double b, double urdf_offset,
-                 double shaft_length, double shaft_ticks, double act_length,
-                 double direction);
-
-  std::vector<PublisherTopic> publisher_topics_ = {
-      {"base/set", std::bind(&RoverArmHardwareInterface::base_pos, this,
-                             std::placeholders::_1)},
-      {"act1/set", std::bind(&RoverArmHardwareInterface::act1_pos, this,
-                             std::placeholders::_1)},
-      {"act2/set", std::bind(&RoverArmHardwareInterface::act2_pos, this,
-                             std::placeholders::_1)},
-      {"elbow/set", std::bind(&RoverArmHardwareInterface::elbow_pos, this,
-                              std::placeholders::_1)},
-      {"wristTilt/set", std::bind(&RoverArmHardwareInterface::wrist_tilt_pos,
-                                  this, std::placeholders::_1)},
-      {"wristTurn/set", std::bind(&RoverArmHardwareInterface::wrist_turn_pos,
-                                  this, std::placeholders::_1)},
-  };
-
   std::vector<rclcpp::Subscription<ros_phoenix::msg::MotorStatus>::SharedPtr>
       encoder_subscribers_;
   std::vector<rclcpp::Publisher<ros_phoenix::msg::MotorControl>::SharedPtr>
       motor_publishers_;
-
-  std::vector<ros_phoenix::msg::MotorControl> output_;
-
-  bool encoderPassthrough_ = true;
+  // Service provider for open loop
+  rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr open_loop_service_;
 };
 
 }  // namespace ros2_control_rover_arm

--- a/src/hardware/src/rover_arm.h
+++ b/src/hardware/src/rover_arm.h
@@ -68,7 +68,7 @@ class RoverArmHardwareInterface : public hardware_interface::SystemInterface {
  private:
   // Store the command for the simulated robot
   std::vector<std::string> node_names_;
-  std::vector<double> hw_position_commands_;
+  std::vector<double> hw_commands_;
   std::vector<double> hw_position_states_;
   std::vector<double> hw_velocity_states_;
   std::vector<double> temp_;

--- a/src/joystick_control/CMakeLists.txt
+++ b/src/joystick_control/CMakeLists.txt
@@ -9,6 +9,8 @@ find_package(nav_msgs REQUIRED)
 find_package(joy REQUIRED)
 find_package(ros_phoenix REQUIRED)
 find_package(interfaces REQUIRED)
+find_package(control_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
 
 # Specify the C++ standard
 set(CMAKE_CXX_STANDARD 14)
@@ -17,7 +19,12 @@ set(CMAKE_CXX_STANDARD 14)
 include_directories(include/${PROJECT_NAME})
 
 # Declare the executables for the nodes
-add_executable(flightstick_control src/FlightstickControl.cpp src/DriveMode.cpp src/ArmManualMode.cpp)
+add_executable(flightstick_control 
+  src/FlightstickControl.cpp 
+  src/DriveMode.cpp 
+  src/ArmManualMode.cpp 
+  src/ArmIKMode.cpp
+  src/ArmHelpers.cpp)
 
 # Link the dependencies to the executable
 ament_target_dependencies(flightstick_control
@@ -27,6 +34,8 @@ ament_target_dependencies(flightstick_control
   joy
   ros_phoenix
   interfaces
+  control_msgs
+  std_srvs
 )
 
 # Install the executable

--- a/src/joystick_control/include/joystick_control/ArmHelpers.hpp
+++ b/src/joystick_control/include/joystick_control/ArmHelpers.hpp
@@ -1,0 +1,10 @@
+#ifndef JOYSTICK_CONTROL__ARM_HELPERS_HPP_
+#define JOYSTICK_CONTROL__ARM_HELPERS_HPP_
+
+#include "rclcpp/rclcpp.hpp"
+
+namespace ArmHelpers {
+bool start_moveit_servo(rclcpp::Node* node, int attempts = 3);
+}
+
+#endif

--- a/src/joystick_control/include/joystick_control/ArmIKMode.hpp
+++ b/src/joystick_control/include/joystick_control/ArmIKMode.hpp
@@ -1,0 +1,75 @@
+#ifndef JOYSTICK_CONTROL__ARMIK_MODE_HPP_
+#define JOYSTICK_CONTROL__ARMIK_MODE_HPP_
+
+#include <geometry_msgs/msg/twist_stamped.hpp>
+
+#include "Mode.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+#include "interfaces/srv/move_servo.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+const std::string CAM_FRAME_ID = "eef_link";
+const std::string BASE_FRAME_ID = "Link_1";
+
+class ArmIKMode : public Mode {
+ public:
+  ArmIKMode(rclcpp::Node* node);
+
+  void processJoystickInput(
+      std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) override;
+
+  void handleTwist(std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg);
+  void handleGripper(std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg);
+
+  static void declareParameters(rclcpp::Node* node);
+  void loadParameters();
+
+  /**
+   * @brief Sends a request to move a servo
+   * @param port The servo port number
+   * @param pos The target position
+   * @param min The minimum position limit of the servo
+   * @param max The maximum position limit of the servo
+   * @return The service response
+   */
+  interfaces::srv::MoveServo::Response sendRequest(int port, int pos, int min,
+                                                   int max) const;
+
+  /**
+   * @brief Wrapper for servo control
+   * @param req_port The servo port number
+   * @param req_pos The target position
+   * @param req_min The minimum position limit
+   * @param req_max The maximum position limit
+   */
+  void servoRequest(int req_port, int req_pos, int req_min, int req_max) const;
+
+ private:
+  // Servo Members
+  rclcpp::Client<interfaces::srv::MoveServo>::SharedPtr servo_client_;
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr twist_pub_;
+
+  // Servo Constants
+  int8_t kServoPort;
+  int8_t kServoMin;
+  int8_t kServoMax;
+  int8_t kClawMax;
+  int8_t kClawMin;
+  int8_t kxAxis;
+  int8_t kyAxis;
+  int8_t kUpBut;
+  int8_t kDownBut;
+  int8_t kAroundX;
+  int8_t kAroundY;
+  int8_t kAroundZ;
+  int8_t kBase;
+  int8_t kEEF;
+  int8_t kClawOpen;
+  int8_t kClawClose;
+  int8_t servoPos_;
+  bool buttonPressed_;
+  bool swapButton_;
+  std::string frame_to_publish_;
+};
+
+#endif  // JOYSTICK_CONTROL__ARMIK_MODE_HPP_

--- a/src/joystick_control/include/joystick_control/ArmManualMode.hpp
+++ b/src/joystick_control/include/joystick_control/ArmManualMode.hpp
@@ -2,10 +2,11 @@
 #define JOYSTICK_CONTROL__ARMMANUAL_MODE_HPP_
 
 #include "Mode.hpp"
+#include "control_msgs/msg/joint_jog.hpp"
 #include "geometry_msgs/msg/twist.hpp"
 #include "interfaces/srv/move_servo.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "ros_phoenix/msg/motor_control.hpp"
+#include "sensor_msgs/msg/joy.hpp"
 
 /**
  * @class ArmManualMode
@@ -60,7 +61,7 @@ class ArmManualMode : public Mode {
    *
    * @param joystickMsg A shared pointer to the sensor_msgs::msg::Joy message.
    */
-  void handleTwist(std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) const;
+  void handleTwist(std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg);
 
   /**
    * @brief Gets the throttle value from the joystick input.
@@ -95,26 +96,14 @@ class ArmManualMode : public Mode {
   int8_t kSimpleBackward;  ///< Button to move the end effector backward
 
   // Publishers
-  rclcpp::Publisher<ros_phoenix::msg::MotorControl>::SharedPtr base_pub_;
-  rclcpp::Publisher<ros_phoenix::msg::MotorControl>::SharedPtr act1_pub_;
-  rclcpp::Publisher<ros_phoenix::msg::MotorControl>::SharedPtr act2_pub_;
-  rclcpp::Publisher<ros_phoenix::msg::MotorControl>::SharedPtr elbow_pub_;
-  rclcpp::Publisher<ros_phoenix::msg::MotorControl>::SharedPtr wristTilt_pub_;
-  rclcpp::Publisher<ros_phoenix::msg::MotorControl>::SharedPtr wristTurn_pub_;
+  rclcpp::Publisher<control_msgs::msg::JointJog>::SharedPtr
+      joint_pub_;  ///< Publisher for joint jog messages.
 
-  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr
-      twist_pub_;  ///< Publisher for Twist messages.
-
-  // MotorControl Messages
-  mutable ros_phoenix::msg::MotorControl base_;
-  mutable ros_phoenix::msg::MotorControl act1_;
-  mutable ros_phoenix::msg::MotorControl act2_;
-  mutable ros_phoenix::msg::MotorControl elbow_;
-  mutable ros_phoenix::msg::MotorControl wristTilt_;
-  mutable ros_phoenix::msg::MotorControl wristTurn_;
+  // Message Messages
+  control_msgs::msg::JointJog joint_msg_;
 
   // Servo Members
-  mutable rclcpp::Client<interfaces::srv::MoveServo>::SharedPtr servo_client_;
+  rclcpp::Client<interfaces::srv::MoveServo>::SharedPtr servo_client_;
 
   // Servo Constants
   int8_t kServoPort;
@@ -122,10 +111,10 @@ class ArmManualMode : public Mode {
   int8_t kServoMax;
   int8_t kClawMax;
   int8_t kClawMin;
-  mutable double act1Scaler;
-  mutable double act2Scaler;
-  mutable int8_t servoPos;
-  mutable bool buttonPressed;
+  double act1Scaler_;
+  double act2Scaler_;
+  int8_t servoPos_;
+  bool buttonPressed_;
 };
 
 #endif  // JOYSTICK_CONTROL__ARMMANUAL_MODE_HPP_

--- a/src/joystick_control/include/joystick_control/FlightstickControl.hpp
+++ b/src/joystick_control/include/joystick_control/FlightstickControl.hpp
@@ -1,6 +1,7 @@
 #ifndef FLIGHTSTICK_CONTROL_HPP
 #define FLIGHTSTICK_CONTROL_HPP
 
+#include "ArmIKMode.hpp"
 #include "ArmManualMode.hpp"
 #include "DriveMode.hpp"
 #include "geometry_msgs/msg/twist.hpp"

--- a/src/joystick_control/src/ArmHelpers.cpp
+++ b/src/joystick_control/src/ArmHelpers.cpp
@@ -1,0 +1,20 @@
+#include "ArmHelpers.hpp"
+
+#include "std_srvs/srv/trigger.hpp"
+
+bool ArmHelpers::start_moveit_servo(rclcpp::Node* node, int attempts) {
+  auto start_moveit_client =
+      node->create_client<std_srvs::srv::Trigger>("/servo_node/start_servo");
+  int i = 0;
+  while (!start_moveit_client->wait_for_service(std::chrono::seconds(1))) {
+    RCLCPP_WARN(node->get_logger(), "Service not available, Waiting...");
+    if (++i >= attempts) {
+      RCLCPP_ERROR(node->get_logger(),
+                   "Service not available after %d attempts. Quiting...", i);
+      return false;
+    }
+  }
+  auto start_request = std::make_shared<std_srvs::srv::Trigger::Request>();
+  start_moveit_client->async_send_request(start_request);
+  return true;
+}

--- a/src/joystick_control/src/ArmIKMode.cpp
+++ b/src/joystick_control/src/ArmIKMode.cpp
@@ -1,0 +1,171 @@
+#include "ArmIKMode.hpp"
+
+#include "ArmHelpers.hpp"
+
+ArmIKMode::ArmIKMode(rclcpp::Node* node) : Mode("IK Arm", node) {
+  RCLCPP_INFO(node_->get_logger(), "IK Arm Mode");
+  loadParameters();
+
+  servo_client_ =
+      node_->create_client<interfaces::srv::MoveServo>("servo_service");
+  twist_pub_ = node_->create_publisher<geometry_msgs::msg::TwistStamped>(
+      "/servo_node/delta_twist_cmds", 10);
+  if (!ArmHelpers::start_moveit_servo(node_)) {
+    return;
+  }
+  frame_to_publish_ = CAM_FRAME_ID;
+  kServoMin = 0;
+  kServoMax = 180;
+  kClawMax = 62;
+  kClawMin = 8;
+  servoPos_ = kClawMax;
+  servoRequest(kServoPort, servoPos_, kServoMin, kServoMax);
+  buttonPressed_ = false;
+  swapButton_ = false;
+}
+
+void ArmIKMode::processJoystickInput(
+    std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) {
+  handleTwist(joystickMsg);
+}
+
+void ArmIKMode::handleTwist(
+    std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) {
+  geometry_msgs::msg::TwistStamped twist_msg;
+  twist_msg.header.stamp = node_->now();
+  twist_msg.header.frame_id = frame_to_publish_;
+
+  twist_msg.twist.linear.x = joystickMsg->axes[kxAxis];
+  twist_msg.twist.linear.y = -joystickMsg->axes[kyAxis];
+  twist_msg.twist.linear.z =
+      joystickMsg->buttons[kUpBut] - joystickMsg->buttons[kDownBut];
+  twist_msg.twist.angular.x = joystickMsg->axes[kAroundX];
+  twist_msg.twist.angular.y = joystickMsg->axes[kAroundY];
+  twist_msg.twist.angular.z = joystickMsg->axes[kAroundZ];
+
+  if (joystickMsg->buttons[kBase] == 1 && !swapButton_) {
+    frame_to_publish_ = BASE_FRAME_ID;
+    swapButton_ = true;
+  } else if (joystickMsg->buttons[kEEF] == 1 && !swapButton_) {
+    frame_to_publish_ = CAM_FRAME_ID;
+    swapButton_ = true;
+  } else if (!joystickMsg->buttons[kEEF] == 1 &&
+             joystickMsg->buttons[kBase] == 1) {
+    swapButton_ = false;
+  }
+  twist_pub_->publish(twist_msg);
+}
+void ArmIKMode::handleGripper(
+    std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) {
+  // Gripper. Will cycle between open, half open, and close on button release.
+  if (joystickMsg->buttons[kClawOpen] == 1 && !buttonPressed_) {
+    if (servoPos_ + ((kClawMax - kClawMin) / 2) < kClawMax + 1) {
+      buttonPressed_ = true;
+      servoPos_ = servoPos_ + ((kClawMax - kClawMin) / 2);
+      servoRequest(kServoPort, servoPos_, kClawMin, kClawMax);
+    } else {
+      buttonPressed_ = true;
+      RCLCPP_INFO(node_->get_logger(), "Max Open");
+      RCLCPP_INFO(node_->get_logger(), "%d", servoPos_);
+    }
+  } else if (joystickMsg->buttons[kClawClose] == 1 && !buttonPressed_) {
+    if (servoPos_ - ((kClawMax - kClawMin) / 2) > kClawMin - 1) {
+      buttonPressed_ = true;
+      servoPos_ = servoPos_ - ((kClawMax - kClawMin) / 2);
+      servoRequest(kServoPort, servoPos_, kClawMin, kClawMax);
+    } else {
+      buttonPressed_ = true;
+      RCLCPP_INFO(node_->get_logger(), "Max Close");
+      RCLCPP_INFO(node_->get_logger(), "%d", servoPos_);
+    }
+  } else if ((joystickMsg->buttons[kClawClose] == 0) &&
+             (joystickMsg->buttons[kClawOpen] == 0)) {
+    buttonPressed_ = false;
+  }
+}
+
+void ArmIKMode::declareParameters(rclcpp::Node* node) {
+  node->declare_parameter("arm_ik_mode.x_axis", 0);
+  node->declare_parameter("arm_ik_mode.y_axis", 1);
+  node->declare_parameter("arm_ik_mode.up_button", 2);
+  node->declare_parameter("arm_ik_mode.down_button", 3);
+  node->declare_parameter("arm_ik_mode.rotate_around_y", 4);
+  node->declare_parameter("arm_ik_mode.rotate_around_x", 5);
+  node->declare_parameter("arm_ik_mode.rotate_around_z", 6);
+  node->declare_parameter("arm_ik_mode.open_claw", 7);
+  node->declare_parameter("arm_ik_mode.close_claw", 8);
+  node->declare_parameter("arm_ik_mode.base_frame", 9);
+  node->declare_parameter("arm_ik_mode.eef_frame", 10);
+}
+
+void ArmIKMode::loadParameters() {
+  node_->get_parameter("arm_ik_mode.x_axis", kxAxis);
+  node_->get_parameter("arm_ik_mode.y_axis", kyAxis);
+  node_->get_parameter("arm_ik_mode.up_button", kUpBut);
+  node_->get_parameter("arm_ik_mode.down_button", kDownBut);
+  node_->get_parameter("arm_ik_mode.rotate_around_y", kAroundY);
+  node_->get_parameter("arm_ik_mode.rotate_around_x", kAroundX);
+  node_->get_parameter("arm_ik_mode.rotate_around_z", kAroundZ);
+  node_->get_parameter("arm_ik_mode.open_claw", kClawOpen);
+  node_->get_parameter("arm_ik_mode.close_claw", kClawClose);
+  node_->get_parameter("arm_ik_mode.base_frame", kBase);
+  node_->get_parameter("arm_ik_mode.eef_frame", kEEF);
+}
+
+interfaces::srv::MoveServo::Response ArmIKMode::sendRequest(int port, int pos,
+                                                            int min,
+                                                            int max) const {
+  auto request = std::make_shared<interfaces::srv::MoveServo::Request>();
+  request->port = port;
+  request->pos = pos;
+  request->min = min;
+  request->max = max;
+
+  // Wait for the service to be available
+  if (!servo_client_->wait_for_service(std::chrono::seconds(1))) {
+    RCLCPP_WARN(node_->get_logger(), "Service not available after waiting");
+    return interfaces::srv::MoveServo::Response();
+  }
+
+  auto future = servo_client_->async_send_request(request);
+
+  // Wait for the result (with timeout)
+  if (rclcpp::spin_until_future_complete(node_->get_node_base_interface(),
+                                         future, std::chrono::seconds(1)) !=
+      rclcpp::FutureReturnCode::SUCCESS) {
+    RCLCPP_ERROR(node_->get_logger(), "Service call failed");
+    return interfaces::srv::MoveServo::Response();
+  }
+
+  return *future.get();
+}
+
+void ArmIKMode::servoRequest(int req_port, int req_pos, int req_min,
+                             int req_max) const {
+  auto request = std::make_shared<interfaces::srv::MoveServo::Request>();
+  request->port = req_port;
+  request->pos = req_pos;
+  request->min = req_min;
+  request->max = req_max;
+
+  if (!servo_client_->wait_for_service(std::chrono::seconds(1))) {
+    RCLCPP_WARN(node_->get_logger(), "Service not available");
+    return;
+  }
+
+  // Simple callback that just logs errors
+  auto callback =
+      [this](rclcpp::Client<interfaces::srv::MoveServo>::SharedFuture future) {
+        try {
+          auto response = future.get();
+          if (!response->status) {
+            RCLCPP_ERROR(node_->get_logger(), "Servo move failed");
+          }
+        } catch (const std::exception& e) {
+          RCLCPP_ERROR(node_->get_logger(), "Service call failed: %s",
+                       e.what());
+        }
+      };
+
+  servo_client_->async_send_request(request, callback);
+}

--- a/src/joystick_control/src/FlightstickControl.cpp
+++ b/src/joystick_control/src/FlightstickControl.cpp
@@ -56,6 +56,10 @@ bool FlightstickControl::changeMode(ModeType mode) {
       RCLCPP_INFO(this->get_logger(), "Entering Manual Mode");
       mode_ = std::make_unique<ArmManualMode>(this);
       return true;
+    case ModeType::ARM_IK:
+      RCLCPP_INFO(this->get_logger(), "Entering IK Mode");
+      mode_ = std::make_unique<ArmIKMode>(this);
+      return true;
     default:
       RCLCPP_WARN(this->get_logger(),
                   "Mode not implemented, returning to NONE");
@@ -74,6 +78,7 @@ void FlightstickControl::declareParameters() {
   this->declare_parameter("science_mode_button", 14);
   DriveMode::declareParameters(this);
   ArmManualMode::declareParameters(this);
+  ArmIKMode::declareParameters(this);
 }
 
 void FlightstickControl::loadParameters() {

--- a/src/ros_phoenix_humble/include/ros_phoenix/base_node.hpp
+++ b/src/ros_phoenix_humble/include/ros_phoenix/base_node.hpp
@@ -45,6 +45,7 @@ class BaseNode : public Node {
 
   int follow_id_;
   double sensor_multiplier_ = 1.0;
+  double sensor_offset_ = 0.0;
 
   bool configured_ = false;
   std::mutex config_mutex_;

--- a/src/ros_phoenix_humble/include/ros_phoenix/phoenix_node.hpp
+++ b/src/ros_phoenix_humble/include/ros_phoenix/phoenix_node.hpp
@@ -46,7 +46,8 @@ class PhoenixNode : public BaseNode {
     status->output_current = this->get_output_current();
 
     status->position = this->controller_->GetSelectedSensorPosition() *
-                       this->sensor_multiplier_;
+                           this->sensor_multiplier_ -
+                       this->sensor_offset_;
     // CTRE library returns velocity in units/100ms. Multiply by 10 to get
     // units/s.
     status->velocity = this->controller_->GetSelectedSensorVelocity() * 10.0 *
@@ -68,8 +69,8 @@ class PhoenixNode : public BaseNode {
       this->controller_->Set(
           mode, control_msg->value / 10.0 / this->sensor_multiplier_);
     } else if (mode == ControlMode::Position) {
-      this->controller_->Set(mode,
-                             control_msg->value / this->sensor_multiplier_);
+      this->controller_->Set(mode, (this->sensor_offset_ + control_msg->value) /
+                                       this->sensor_multiplier_);
     } else if (mode == ControlMode::PercentOutput ||
                mode == ControlMode::Disabled) {
       this->controller_->Set(mode, control_msg->value);
@@ -114,7 +115,6 @@ class PhoenixNode : public BaseNode {
           RCLCPP_WARN(
               this->get_logger(),
               "Motor controller has not been seen and cannot be configured!");
-          warned = true;
         }
         continue;
       }

--- a/src/ros_phoenix_humble/include/ros_phoenix/phoenix_system.hpp
+++ b/src/ros_phoenix_humble/include/ros_phoenix/phoenix_system.hpp
@@ -30,16 +30,18 @@ class PhoenixSystem : public hardware_interface::SystemInterface {
 
   ~PhoenixSystem() = default;
 
-  hardware_interface::return_type configure(
+  hardware_interface::CallbackReturn on_init(
       const hardware_interface::HardwareInfo &info);
 
   std::vector<hardware_interface::StateInterface> export_state_interfaces();
 
   std::vector<hardware_interface::CommandInterface> export_command_interfaces();
 
-  hardware_interface::return_type start();
+  hardware_interface::CallbackReturn on_activate(
+      const rclcpp_lifecycle::State & /*previous_state*/);
 
-  hardware_interface::return_type stop();
+  hardware_interface::CallbackReturn on_deactivate(
+      const rclcpp_lifecycle::State & /*previous_state*/);
 
   hardware_interface::return_type read(const rclcpp::Time &time,
                                        const rclcpp::Duration &period) override;

--- a/src/ros_phoenix_humble/src/base_node.cpp
+++ b/src/ros_phoenix_humble/src/base_node.cpp
@@ -27,11 +27,13 @@ BaseNode::BaseNode(const std::string &name, const rclcpp::NodeOptions &options)
                                        // for Falcon built-in encoder)
   this->declare_parameter<bool>("invert", false);
   this->declare_parameter<bool>("invert_sensor", false);
+  this->declare_parameter<bool>("non_continuous", false);
   this->declare_parameter<bool>("brake_mode", true);
   this->declare_parameter<int>("input_type", RELATIVE);
   this->declare_parameter<double>("max_voltage", 12);
   this->declare_parameter<double>("max_current", 30);
   this->declare_parameter<double>("sensor_multiplier", 1.0);
+  this->declare_parameter<double>("sensor_offset", 0.0);
 
   this->declare_parameter<double>("P", 0);
   this->declare_parameter<double>("I", 0);
@@ -45,6 +47,7 @@ BaseNode::BaseNode(const std::string &name, const rclcpp::NodeOptions &options)
   this->follow_id_ = this->get_parameter("follow_id").as_int();
   this->sensor_multiplier_ =
       this->get_parameter("sensor_multiplier").as_double();
+  this->sensor_offset_ = this->get_parameter("sensor_offset").as_double();
 
   this->last_update_ = this->now();
 
@@ -104,6 +107,8 @@ rcl_interfaces::msg::SetParametersResult BaseNode::reconfigure(
 
     } else if (param.get_name() == "sensor_multiplier") {
       this->sensor_multiplier_ = param.as_double();
+    } else if (param.get_name() == "sensor_offset") {
+      this->sensor_offset_ = param.as_double();
     }
   }
 

--- a/src/ros_phoenix_humble/src/phoenix_nodes.cpp
+++ b/src/ros_phoenix_humble/src/phoenix_nodes.cpp
@@ -37,11 +37,13 @@ void TalonSRXNode::configure_current_limit(TalonSRXConfiguration &config) {
       this->get_parameter("max_current").as_double();
   config.peakCurrentLimit = this->get_parameter("max_current").as_double();
   config.peakCurrentDuration = 100;  // ms
-
   this->controller_->EnableCurrentLimit(true);
 }
 
 void TalonSRXNode::configure_sensor() {
+  if (this->get_parameter("non_continuous").as_bool()) {
+    this->controller_->ConfigFeedbackNotContinuous(true);
+  }
   if (this->get_parameter("input_type").as_int() == ANALOG)
     this->controller_->ConfigSelectedFeedbackSensor(
         TalonSRXFeedbackDevice::Analog);


### PR DESCRIPTION
Uses a velocity control IK model. Testing results are not bad. Still room for more tuning and significant room for practicing.

In the event that we do have time to finalize the keyboard autonomous typing we can easily add a secondary config + launch files for that.

This pull request introduces significant updates to the arm control configuration, including changes to velocity scaling, joint limits, and URDF structure, as well as enhancements to the ROS2 launch files and controllers. These changes aim to improve the arm's performance, simplify configuration, and align with updated hardware and software requirements.

### Configuration Updates
* Increased the maximum joint velocity from `0.5` to `2.0` in `arm_config.yaml`, enabling faster joint movements.
* Changed `command_out_type` to `std_msgs/Float64MultiArray` and updated `publish_joint_positions` and `publish_joint_velocities` settings for better compatibility with the robot driver.
* Adjusted singularity thresholds and joint limit margins to improve motion planning near singularities.

### URDF and Hardware Interface Changes
* Added a new `eef_link` and `eef_joint` to the URDF for better end-effector representation.
* Updated velocity limits and joint types in the URDF to reflect new hardware capabilities, including making `Joint_6` continuous. [[1]](diffhunk://#diff-182dc86b915aed470c65cf0059c62d15c61a4eea828d34b4aedecb7445927a78L359-R365) [[2]](diffhunk://#diff-182dc86b915aed470c65cf0059c62d15c61a4eea828d34b4aedecb7445927a78L207-R213)
* Removed dependency on initial positions in `arm_urdf.ros2_control.xacro` and added `node_name` parameters for hardware-specific configuration.

### Controller and Launch File Updates
* Switched the controller type to `velocity_controllers/JointGroupVelocityController` in `ros2_controllers.yaml` for velocity-based control.
* Disabled RViz by default in `servo.launch.py` and removed unused nodes to streamline the launch process. [[1]](diffhunk://#diff-79ae34decadab119cb93abc70fdb297ea6149906dfca9ae0b0f79754ac5e90a7L75-R75) [[2]](diffhunk://#diff-79ae34decadab119cb93abc70fdb297ea6149906dfca9ae0b0f79754ac5e90a7L165-L175)
* Enhanced `talon.launch.py` with additional parameters for TalonSRX motor controllers, including sensor offsets, multipliers, and voltage limits.

### Dependency and Miscellaneous Updates
* Added new dependencies like `moveit_servo` and `ros_phoenix` to `package.xml` while removing unused ones.
* Fixed a typo in `kinematics.yaml` and removed unnecessary configurations.