### PR TITLE
Implement decaying inflation after core inflation

### DIFF
--- a/src/cprt_gridmap_filters/include/PreserveCostInflationFilter.hpp
+++ b/src/cprt_gridmap_filters/include/PreserveCostInflationFilter.hpp
@@ -76,8 +76,14 @@ class PreserveCostInflationFilter : public filters::FilterBase<T> {
   // Inflation method
   Method method_;
 
-  // Inflation radius
-  double inflationRadius_;
+  // Core Inflation radius
+  double coreInflationRadius_;
+
+  // Decay inflation radius
+  double decayInflationRadius_;
+
+  // Decay rate
+  double decayRate_;
 
 };  // class PreserveCostInflationFilter
 

--- a/src/cprt_gridmap_filters/scripts/calculate_decay_rate.py
+++ b/src/cprt_gridmap_filters/scripts/calculate_decay_rate.py
@@ -1,0 +1,98 @@
+import math
+
+
+def calculate_decay_rate(core_radius, decay_radius, inflation_value, target_cost):
+    """
+    Calculates the decay rate for exponential inflation falloff.
+
+    Args:
+      core_radius (float): The radius within which inflation is at its maximum.
+      decay_radius (float): The maximum radius of inflation influence.
+      inflation_value (float): The inflation cost at the edge of the core radius.
+      target_cost (float): The desired inflation cost at the decay radius.
+
+    Returns:
+      float: The calculated decay rate, or None if inputs are invalid.
+    """
+    if (
+        decay_radius <= core_radius
+        or target_cost <= 0
+        or target_cost >= inflation_value
+    ):
+        print("Invalid input parameters for decay rate calculation.")
+        return None
+    else:
+        decay_rate = math.log(inflation_value / target_cost) / (
+            decay_radius - core_radius
+        )
+        return decay_rate
+
+
+if __name__ == "__main__":
+    print("Calculating decay rate for exponential inflation...")
+
+    core_radius = float(input("Enter the core inflation radius (e.g., 0.5): "))
+    decay_radius = float(input("Enter the decay inflation radius (e.g., 1.5): "))
+    inflation_value = float(
+        input("Enter the inflation value at the core radius (e.g., 1.0): ")
+    )
+    target_cost = float(
+        input("Enter the desired target cost at the decay radius (e.g., 0.1): ")
+    )
+
+    decay_rate = calculate_decay_rate(
+        core_radius, decay_radius, inflation_value, target_cost
+    )
+
+    if decay_rate is not None:
+        print(f"\nCalculated decay rate: {decay_rate:.4f}")
+        print("\nYou can use this value for your 'decayRate_' parameter.")
+
+        # --- Optional: Visualize the decay ---
+        import numpy as np
+        import matplotlib.pyplot as plt
+
+        distances = np.linspace(0, decay_radius, 100)
+        decayed_costs = np.piecewise(
+            distances,
+            [distances <= core_radius, distances > core_radius],
+            [
+                inflation_value,
+                lambda d: inflation_value * np.exp(-decay_rate * (d - core_radius)),
+            ],
+        )
+
+        plt.figure(figsize=(8, 6))
+        plt.plot(distances, decayed_costs)
+        plt.xlabel("Distance from Obstacle Center")
+        plt.ylabel("Inflation Cost")
+        plt.title("Exponential Cost Decay with Flat Core Cost")
+        plt.axvline(
+            core_radius,
+            color="r",
+            linestyle="--",
+            label=f"Core Radius: {core_radius:.2f}",
+        )
+        plt.axvline(
+            decay_radius,
+            color="g",
+            linestyle="--",
+            label=f"Decay Radius: {decay_radius:.2f}",
+        )
+        plt.scatter(
+            decay_radius,
+            target_cost,
+            color="g",
+            marker="o",
+            label=f"Target Cost: {target_cost:.2f}",
+        )
+        plt.scatter(
+            core_radius,
+            inflation_value,
+            color="r",
+            marker="o",
+            label=f"Initial Cost: {inflation_value:.2f}",
+        )
+        plt.grid(True)
+        plt.legend()
+        plt.show()

--- a/src/cprt_gridmap_filters/scripts/visualize_decay_rate.py
+++ b/src/cprt_gridmap_filters/scripts/visualize_decay_rate.py
@@ -1,0 +1,76 @@
+import math
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def visualize_decay_with_cutoff(core_radius, decay_radius, decay_rate, start_value):
+    """
+    Visualizes the exponential decay of inflation cost with a cutoff at the decay radius.
+
+    Args:
+      core_radius (float): The radius within which inflation is at its start value.
+      decay_radius (float): The maximum radius of inflation influence.
+      decay_rate (float): The rate of exponential decay.
+      start_value (float): The inflation cost within the core radius.
+    """
+    distances = np.linspace(0, decay_radius * 1.2, 200)
+    decayed_costs = np.piecewise(
+        distances,
+        [
+            distances <= core_radius,
+            (distances > core_radius) & (distances <= decay_radius),
+            distances > decay_radius,
+        ],
+        [
+            start_value,
+            lambda d: start_value * np.exp(-decay_rate * (d - core_radius)),
+            0,
+        ],
+    )
+
+    plt.figure(figsize=(10, 7))
+    plt.plot(distances, decayed_costs)
+    plt.xlabel("Distance from Obstacle Center")
+    plt.ylabel("Inflation Cost")
+    plt.title("Visualization of Exponential Cost Decay with Cutoff")
+    plt.axvline(
+        core_radius, color="r", linestyle="--", label=f"Core Radius: {core_radius:.2f}"
+    )
+    plt.axvline(
+        decay_radius,
+        color="g",
+        linestyle="--",
+        label=f"Decay Radius: {decay_radius:.2f}",
+    )
+    plt.hlines(
+        0, 0, decay_radius * 1.2, colors="k", linestyles="-", linewidth=0.5
+    )  # Indicate zero cost
+    plt.scatter(
+        core_radius,
+        start_value,
+        color="r",
+        marker="o",
+        label=f"Start Value: {start_value:.2f}",
+    )
+    plt.scatter(
+        decay_radius, 0, color="g", marker="o", label=f"Cost at Decay Radius: 0.00"
+    )  # Mark cutoff
+
+    plt.grid(True)
+    plt.legend()
+    plt.ylim(bottom=-0.1)  # Extend y-axis slightly to show zero
+    plt.xlim(left=0)
+    plt.show()
+
+
+if __name__ == "__main__":
+    print("Visualizing exponential inflation decay with cutoff...")
+
+    core_radius = float(input("Enter the core inflation radius (e.g., 0.5): "))
+    decay_radius = float(input("Enter the decay inflation radius (e.g., 1.5): "))
+    decay_rate = float(input("Enter the decay rate (e.g., 1.0): "))
+    start_value = float(
+        input("Enter the starting inflation value within the core radius (e.g., 1.0): ")
+    )
+
+    visualize_decay_with_cutoff(core_radius, decay_radius, decay_rate, start_value)

--- a/src/navigation/config/elevation_mapping/postprocessing_traversability.yaml
+++ b/src/navigation/config/elevation_mapping/postprocessing_traversability.yaml
@@ -142,4 +142,6 @@ elevation_mapping:
         params:
           input_layer: traversability
           output_layer: inflated_traversability
-          inflation_radius: 0.6 # in m
+          core_inflation_radius: 0.4 # in m
+          decay_inflation_radius: 1.5 # in m
+          decay_rate: 2.2 # See script at /src/cprt_grid_map_filters/scripts/calculate_decay_rate.py to help calculate.

--- a/src/navigation/config/elevation_mapping/postprocessing_traversability.yaml
+++ b/src/navigation/config/elevation_mapping/postprocessing_traversability.yaml
@@ -143,5 +143,5 @@ elevation_mapping:
           input_layer: traversability
           output_layer: inflated_traversability
           core_inflation_radius: 0.5 # in m
-          decay_inflation_radius: 1.5 # in m
+          decay_inflation_radius: 1.1 # in m
           decay_rate: 2.3 # See script at /src/cprt_grid_map_filters/scripts/calculate_decay_rate.py to help calculate.

--- a/src/navigation/config/elevation_mapping/postprocessing_traversability.yaml
+++ b/src/navigation/config/elevation_mapping/postprocessing_traversability.yaml
@@ -142,6 +142,6 @@ elevation_mapping:
         params:
           input_layer: traversability
           output_layer: inflated_traversability
-          core_inflation_radius: 0.4 # in m
+          core_inflation_radius: 0.5 # in m
           decay_inflation_radius: 1.5 # in m
-          decay_rate: 2.2 # See script at /src/cprt_grid_map_filters/scripts/calculate_decay_rate.py to help calculate.
+          decay_rate: 2.3 # See script at /src/cprt_grid_map_filters/scripts/calculate_decay_rate.py to help calculate.


### PR DESCRIPTION
Implemented a decaying inflation with an equation stolen from the nav2 inflation filter.
![image](https://github.com/user-attachments/assets/30ed1bd7-49ff-4f11-9dbe-8224c11416c3)

My inflation is different though. It will inflate like previously to a core inflation radius value, then it will have a decaying inflation from that radius to the decay inflation radius value. 

The current values I have are:
core_inflation_radius=0.4m
decay_inflation_radius=1.5m
decay_rate=2.2
Which can be shown by the following graph showing distance from the main point and inflated value given the original point was 1.0 cost:
![image](https://github.com/user-attachments/assets/a77eaac3-8258-4401-bffe-799e9ffdcd5b)

Or if the original point was 0.5 cost:
![image](https://github.com/user-attachments/assets/7b6755e5-c2b7-43a2-bafd-90e335f8bb42)

And here is what the grid map looks like in rviz:
![Screenshot from 2025-05-10 00-38-05](https://github.com/user-attachments/assets/f1ce7614-ea32-4974-b74b-3e7d0c303a98)

Here is what it looks like between the EDC rocks:
![Screenshot from 2025-05-10 01-18-17](https://github.com/user-attachments/assets/0e2b326c-011a-49f0-9dc8-58e60842368a)

Here is what the EDC bikes and bike stand looks like (a very airy obstacle):
![Screenshot from 2025-05-10 01-21-10](https://github.com/user-attachments/assets/3739a3dc-371a-43cf-b6b2-daa2fcbc22f5)

