### PR TITLE
Mostly science focus but a mostly a sh*t tonne of bug fixes

### DIFF
--- a/setup/science/start_science.sh
+++ b/setup/science/start_science.sh
@@ -24,7 +24,7 @@ docker run -d --rm --name servo_container ${DOCKER_ARGS} ${IMAGE}:${TAG} \
 docker run -d --rm --name sensor_container ${DOCKER_ARGS} ${IMAGE}:${TAG} \
     ros2 launch science_sensors gas_sensor.launch.py
 
-docker run -d --rm --name sensor_container ${DOCKER_ARGS} ${IMAGE}:${TAG} \
+docker run -d --rm --name gpio_container ${DOCKER_ARGS} ${IMAGE}:${TAG} \
     ros2 launch science_sensors gpio.launch.py
 
 gst-launch-1.0 libcamerasrc ! queue ! jpegenc ! jpegparse ! rtpjpegpay ! queue ! udpsink host=${JETSON_IP} port=${PORT} 

--- a/setup/science/start_science.sh
+++ b/setup/science/start_science.sh
@@ -24,6 +24,9 @@ docker run -d --rm --name servo_container ${DOCKER_ARGS} ${IMAGE}:${TAG} \
 docker run -d --rm --name sensor_container ${DOCKER_ARGS} ${IMAGE}:${TAG} \
     ros2 launch science_sensors gas_sensor.launch.py
 
+docker run -d --rm --name sensor_container ${DOCKER_ARGS} ${IMAGE}:${TAG} \
+    ros2 launch science_sensors gpio.launch.py
+
 gst-launch-1.0 libcamerasrc ! queue ! jpegenc ! jpegparse ! rtpjpegpay ! queue ! udpsink host=${JETSON_IP} port=${PORT} 
 
 wait

--- a/src/camera_streaming/config/webrtc.yaml
+++ b/src/camera_streaming/config/webrtc.yaml
@@ -4,12 +4,16 @@ webrtc_node:
   ros__parameters:
     camera_name:
     - "Drive"
-    - "Secondary"
+    - "EndEffector"
+    - "Bottom"
     - "Microscope"
     Drive:
       path: "/dev/v4l/by-id/usb-Arducam_Arducam_B0495__USB3_2.3MP__Arducam_20231205_0001-video-index0"
       type: 0
-    Secondary:
+    EndEffector:
+      path: "/dev/v4l/by-id/usb-EMEET_HD_Webcam_eMeet_C950_SN0001-video-index0"
+      type: 0
+    Bottom:
       path: "/dev/v4l/by-id/usb-HD_Camera_Manufacturer_USB_2.0_Camera-video-index0"
       type: 0
       encoded: true

--- a/src/drive/config/pxn.yaml
+++ b/src/drive/config/pxn.yaml
@@ -18,11 +18,14 @@ flightstick_control:
       cam_reset: 1
       cam_next: 3
       cam_prev: 2
+      camera_speed: 3.0
       cruise_control: 0
       max_linear: 2.0
       max_angular: 1.0
       max_increment: 0.1
       min_speed: 0.001
+      default_pan: 120.0
+      default_tilt: 190.0
       
     arm_manual_mode:
       throttle:
@@ -61,9 +64,11 @@ flightstick_control:
       microscope_axis: 5
       soil_collection_button: 5
       cancel_collection_button: 3
+      microscope_light_button: 4
       microscope_servo: 0
       collection_servo: 1
-      panoramic_button: 4
+      panoramic_button: 2
       collection_open: 0
       collection_close: 120
+      throttle_axis: 2
 

--- a/src/joystick_control/include/joystick_control/DriveMode.hpp
+++ b/src/joystick_control/include/joystick_control/DriveMode.hpp
@@ -99,6 +99,7 @@ class DriveMode : public Mode {
   double kMinSpeed;               ///< Minimum speed value.
   double kDefaultCamPan = 90.0;   ///< Default camera pan position.
   double kDefaultCamTilt = 90.0;  ///< Default camera tilt position.
+  double kCameraSpeed = 1.0;      ///< Speed for camera movement.
 
   rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr
       twist_pub_;  ///< Publisher for Twist messages.

--- a/src/joystick_control/include/joystick_control/ScienceMode.hpp
+++ b/src/joystick_control/include/joystick_control/ScienceMode.hpp
@@ -24,19 +24,17 @@ class ScienceMode : public Mode {
       std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) const;
   void handlePanoramic(
       std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) const;
-  void handleSoilCollection(std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg);
+  void handleSoilCollection(
+      std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) const;
 
-  void drill_callback(const ros_phoenix::msg::MotorStatus::SharedPtr msg);
-  void platform_callback(const ros_phoenix::msg::MotorStatus::SharedPtr msg);
   void setServoPosition(int port, int position) const;
 
-  void auto_drill_callback();
   void loadParameters();
 
   int8_t kPlatformAxis;
   int8_t kDrillButton;
   int8_t kMicroscopeAxis;
-  int8_t kAutoDrillButton;
+  int8_t kCollectionButton;
   int8_t kCancelCollectionButton;
   int8_t kPanoramicButton;
   int8_t kCollectionServo;
@@ -44,15 +42,10 @@ class ScienceMode : public Mode {
   int16_t kCollectionOpen;
   int16_t kCollectionClose;
 
-  int drillHeight;
-  bool autoDrill;
-
   rclcpp::Publisher<ros_phoenix::msg::MotorControl>::SharedPtr platform_pub_;
   rclcpp::Publisher<ros_phoenix::msg::MotorControl>::SharedPtr drill_pub_;
-  rclcpp::Subscription<ros_phoenix::msg::MotorStatus>::SharedPtr platform_sub_;
   rclcpp::Client<interfaces::srv::MoveServo>::SharedPtr servo_client_;
 
-  rclcpp::TimerBase::SharedPtr autoDrillTimer_;
 };
 
 #endif

--- a/src/joystick_control/include/joystick_control/ScienceMode.hpp
+++ b/src/joystick_control/include/joystick_control/ScienceMode.hpp
@@ -7,6 +7,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "ros_phoenix/msg/motor_control.hpp"
 #include "ros_phoenix/msg/motor_status.hpp"
+#include "std_srvs/srv/set_bool.hpp"
 
 class ScienceMode : public Mode {
  public:
@@ -28,12 +29,14 @@ class ScienceMode : public Mode {
       std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg) const;
 
   void setServoPosition(int port, int position) const;
+  void toggleLights() const;
 
   void loadParameters();
 
   int8_t kPlatformAxis;
   int8_t kDrillButton;
   int8_t kMicroscopeAxis;
+  int8_t kThrottleAxis;
   int8_t kCollectionButton;
   int8_t kCancelCollectionButton;
   int8_t kPanoramicButton;
@@ -46,7 +49,7 @@ class ScienceMode : public Mode {
   rclcpp::Publisher<ros_phoenix::msg::MotorControl>::SharedPtr platform_pub_;
   rclcpp::Publisher<ros_phoenix::msg::MotorControl>::SharedPtr drill_pub_;
   rclcpp::Client<interfaces::srv::MoveServo>::SharedPtr servo_client_;
-  rclcpp::Client<interfaces::srv::MoveServo>::SharedPtr light_client_;
+  rclcpp::Client<std_srvs::srv::SetBool>::SharedPtr led_client_;
 };
 
 #endif

--- a/src/joystick_control/include/joystick_control/ScienceMode.hpp
+++ b/src/joystick_control/include/joystick_control/ScienceMode.hpp
@@ -37,6 +37,7 @@ class ScienceMode : public Mode {
   int8_t kCollectionButton;
   int8_t kCancelCollectionButton;
   int8_t kPanoramicButton;
+  int8_t kMicroscopeLightButton;
   int8_t kCollectionServo;
   int8_t kMicroscopeServo;
   int16_t kCollectionOpen;
@@ -45,7 +46,7 @@ class ScienceMode : public Mode {
   rclcpp::Publisher<ros_phoenix::msg::MotorControl>::SharedPtr platform_pub_;
   rclcpp::Publisher<ros_phoenix::msg::MotorControl>::SharedPtr drill_pub_;
   rclcpp::Client<interfaces::srv::MoveServo>::SharedPtr servo_client_;
-
+  rclcpp::Client<interfaces::srv::MoveServo>::SharedPtr light_client_;
 };
 
 #endif

--- a/src/science_sensors/launch/gpio.launch.py
+++ b/src/science_sensors/launch/gpio.launch.py
@@ -14,5 +14,17 @@ def generate_launch_description():
                     {"gpio_pins": [11, 6]},
                 ],
             ),
+            launch_ros.actions.Node(
+                package="science_sensors",
+                executable="pi_gpio_reader",
+                name="gpio_reader_node",
+                parameters=[
+                    {"gpio_pins": [12]},
+                    {"interval": 1.0},
+                ],
+                remappings=[
+                    ("/gpio/12", "/science/ground"),
+                ],
+            ),
         ]
     )

--- a/src/science_sensors/launch/lights.launch.py
+++ b/src/science_sensors/launch/lights.launch.py
@@ -1,0 +1,18 @@
+import launch
+import launch_ros.actions
+
+
+def generate_launch_description():
+    return launch.LaunchDescription(
+        [
+            launch_ros.actions.Node(
+                package="science_sensors",
+                executable="pi_gpio_controller",
+                name="microscope_light",
+                parameters=[
+                    {"service_name": "/microscope_light"},
+                    {"gpio_pins": [11, 6]},
+                ],
+            ),
+        ]
+    )

--- a/src/science_sensors/science_sensors/gas_sensor.py
+++ b/src/science_sensors/science_sensors/gas_sensor.py
@@ -47,7 +47,12 @@ class GasSensor(Node):
         self.sensor_reading_pub = self.create_publisher(
             GasSensorReading, "gas_sensor", 10
         )
-        self.create_timer(self.get_parameter("gas_sensor_update_interval_s"), self.loop)
+        self.create_timer(
+            self.get_parameter("gas_sensor_update_interval_s")
+            .get_parameter_value()
+            .double_value,
+            self.loop,
+        )
 
     def loop(self):
         """

--- a/src/science_sensors/science_sensors/pi_gpio_controller.py
+++ b/src/science_sensors/science_sensors/pi_gpio_controller.py
@@ -1,0 +1,55 @@
+import rclpy
+from rclpy.node import Node
+from std_srvs.srv import SetBool
+import RPi.GPIO as GPIO
+
+
+class GPIO_Controller(Node):
+    def __init__(self):
+        super().__init__("gpio_service_node")
+        GPIO.setmode(GPIO.BCM)
+        self.load_parameters()
+        for pin in self.gpio_pins:
+            GPIO.setup(pin, GPIO.OUT)
+        self.srv = self.create_service(
+            SetBool, self.service_name, self.set_gpio_callback
+        )
+
+    def load_parameters(self):
+        self.declare_parameter("gpio_pins", [])
+        self.gpio_pins = (
+            self.get_parameter("gpio_pins").get_parameter_value().integer_array_value
+        )
+        if not self.gpio_pins:
+            self.get_logger().error("No GPIO pins provided")
+            raise ValueError("No GPIO pins provided")
+        self.declare_parameter("service_name", "set_gpio")
+        self.service_name = (
+            self.get_parameter("service_name").get_parameter_value().string_value
+        )
+
+    def set_gpio_callback(self, request, response):
+        value = GPIO.HIGH if request.data else GPIO.LOW
+        for pin in self.gpio_pins:
+            GPIO.output(pin, value)
+        response.success = True
+        response.message = f"GPIO pin(s) {'ON' if request.data else 'OFF'}"
+        self.get_logger().info(response.message)
+        return response
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = GPIO_Controller()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        GPIO.cleanup()
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/science_sensors/science_sensors/pi_gpio_reader.py
+++ b/src/science_sensors/science_sensors/pi_gpio_reader.py
@@ -1,0 +1,52 @@
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import Bool
+import RPi.GPIO as GPIO
+
+class GPIOReader(Node):
+    def __init__(self):
+        super().__init__('gpio_reader_node')
+        self.declare_parameter('gpio_pins', [])
+        self.declare_parameter('interval', 1.0)
+
+        self.gpio_pins = self.get_parameter('gpio_pins').get_parameter_value().integer_array_value
+        self.interval = self.get_parameter('interval').get_parameter_value().double_value
+
+        if not self.gpio_pins:
+            self.get_logger().error('No GPIO pins provided')
+            raise ValueError('No GPIO pins provided')
+
+        GPIO.setmode(GPIO.BCM)
+        for pin in self.gpio_pins:
+            GPIO.setup(pin, GPIO.IN)
+
+        self.publishers = {
+            pin: self.create_publisher(Bool, f'/gpio/{pin}', 10) for pin in self.gpio_pins
+        }
+
+        self.timer = self.create_timer(self.interval, self.read_gpio)
+
+        self.get_logger().info(f"Reading GPIO pins {self.gpio_pins} every {self.interval} seconds")
+
+    def read_gpio(self):
+        for pin in self.gpio_pins:
+            value = GPIO.input(pin)
+            msg = Bool()
+            msg.data = bool(value)
+            self.publishers[pin].publish(msg)
+            self.get_logger().debug(f'Published GPIO {pin}: {msg.data}')
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = GPIOReader()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        GPIO.cleanup()
+        node.destroy_node()
+        rclpy.shutdown()
+
+if __name__ == '__main__':
+    main()

--- a/src/science_sensors/science_sensors/pi_gpio_reader.py
+++ b/src/science_sensors/science_sensors/pi_gpio_reader.py
@@ -3,30 +3,38 @@ from rclpy.node import Node
 from std_msgs.msg import Bool
 import RPi.GPIO as GPIO
 
+
 class GPIOReader(Node):
     def __init__(self):
-        super().__init__('gpio_reader_node')
-        self.declare_parameter('gpio_pins', [])
-        self.declare_parameter('interval', 1.0)
+        super().__init__("gpio_reader_node")
+        self.declare_parameter("gpio_pins", [])
+        self.declare_parameter("interval", 1.0)
 
-        self.gpio_pins = self.get_parameter('gpio_pins').get_parameter_value().integer_array_value
-        self.interval = self.get_parameter('interval').get_parameter_value().double_value
+        self.gpio_pins = (
+            self.get_parameter("gpio_pins").get_parameter_value().integer_array_value
+        )
+        self.interval = (
+            self.get_parameter("interval").get_parameter_value().double_value
+        )
 
         if not self.gpio_pins:
-            self.get_logger().error('No GPIO pins provided')
-            raise ValueError('No GPIO pins provided')
+            self.get_logger().error("No GPIO pins provided")
+            raise ValueError("No GPIO pins provided")
 
         GPIO.setmode(GPIO.BCM)
         for pin in self.gpio_pins:
             GPIO.setup(pin, GPIO.IN)
 
         self.publishers = {
-            pin: self.create_publisher(Bool, f'/gpio/{pin}', 10) for pin in self.gpio_pins
+            pin: self.create_publisher(Bool, f"/gpio/{pin}", 10)
+            for pin in self.gpio_pins
         }
 
         self.timer = self.create_timer(self.interval, self.read_gpio)
 
-        self.get_logger().info(f"Reading GPIO pins {self.gpio_pins} every {self.interval} seconds")
+        self.get_logger().info(
+            f"Reading GPIO pins {self.gpio_pins} every {self.interval} seconds"
+        )
 
     def read_gpio(self):
         for pin in self.gpio_pins:
@@ -34,7 +42,8 @@ class GPIOReader(Node):
             msg = Bool()
             msg.data = bool(value)
             self.publishers[pin].publish(msg)
-            self.get_logger().debug(f'Published GPIO {pin}: {msg.data}')
+            self.get_logger().debug(f"Published GPIO {pin}: {msg.data}")
+
 
 def main(args=None):
     rclpy.init(args=args)
@@ -48,5 +57,6 @@ def main(args=None):
         node.destroy_node()
         rclpy.shutdown()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/src/science_sensors/setup.py
+++ b/src/science_sensors/setup.py
@@ -34,6 +34,8 @@ setup(
             "gas_sensor = science_sensors.gas_sensor:main",
             "microscope_control = science_sensors.microscope_control:main",
             "raman = science_sensors.raman:main",
+            "pi_gpio_controller = pi_gpio_controller.raman:main",
+            "pi_gpio_reader = pi_gpio_reader.raman:main",
         ],
     },
 )

--- a/src/science_sensors/setup.py
+++ b/src/science_sensors/setup.py
@@ -34,8 +34,8 @@ setup(
             "gas_sensor = science_sensors.gas_sensor:main",
             "microscope_control = science_sensors.microscope_control:main",
             "raman = science_sensors.raman:main",
-            "pi_gpio_controller = pi_gpio_controller.raman:main",
-            "pi_gpio_reader = pi_gpio_reader.raman:main",
+            "pi_gpio_controller = science_sensors.pi_gpio_controller:main",
+            "pi_gpio_reader = science_sensors.pi_gpio_reader:main",
         ],
     },
 )

--- a/src/servo_pkg/config/pi_controller.yaml
+++ b/src/servo_pkg/config/pi_controller.yaml
@@ -11,6 +11,6 @@ pi_Servo_node:
     # Collection Servo
     servo1:
       out_pin: 19
-      min: 5.0   # Min PWM value
-      max: 10.0  # Max PWM value
+      min: 4.5   # Min PWM value
+      max: 10.5  # Max PWM value
       rom: 180   # 180 degrees

--- a/src/servo_pkg/config/usb_controller.yaml
+++ b/src/servo_pkg/config/usb_controller.yaml
@@ -1,8 +1,13 @@
 USB_Servo_node:
   ros__parameters:
     serial_port: "/dev/serial/by-id/usb-Pololu_Corporation_Pololu_Mini_Maestro_12-Channel_USB_Servo_Controller_00460938-if00"
+    # Tilt
     port0:
-      # these value are for the MS24 servo
-      min: 500
+      min: 350
+      max: 2500
+      rom: 360
+    # PAN
+    port1:
+      min: 350
       max: 2500
       rom: 360


### PR DESCRIPTION
This pull request introduces several enhancements and new features, primarily focusing on Docker integration, ROS 2 setup, and launch configurations for various subsystems. The most significant changes include the addition of a Docker workflow for building and pushing images, updates to ROS 2 installation and dependencies, new launch files for subsystem orchestration, and scripts for managing science-related tasks.

### Docker Integration
* Added a GitHub Actions workflow (`.github/workflows/docker-build-science.yml`) to automate the building and pushing of Docker images for the science subsystem. This includes multi-platform support and tagging based on the GitHub SHA.
* Created a `Dockerfile.science` to define the Docker image for the science subsystem, including ROS 2 setup, Python dependencies, and workspace configuration.
* Added a `build_science.sh` script to locally build the Docker image for the science subsystem.

### ROS 2 Setup and Dependencies
* Updated `setup/install_ros_humble.sh` to include new dependencies (`python3-usb`, `numpy`, `pyusb`) and removed redundant environment variable exports. [[1]](diffhunk://#diff-6eebbc37eba41d8e175a95034a012e2430bcf735b814e3b6c2534c0808e26cb1L33-R34) [[2]](diffhunk://#diff-6eebbc37eba41d8e175a95034a012e2430bcf735b814e3b6c2534c0808e26cb1R55-R56) [[3]](diffhunk://#diff-6eebbc37eba41d8e175a95034a012e2430bcf735b814e3b6c2534c0808e26cb1L42-L46)
* Modified `setup/science/setup_science.sh` to install Docker if not present, configure GStreamer dependencies, and pull the Docker image for the science subsystem.

### Launch Configurations
* Added new launch files (`src/bringup/launch/*.launch.py`) for orchestrating different subsystems, such as navigation, equipment servicing, and science-related tasks. These files include modular and reusable launch descriptions. [[1]](diffhunk://#diff-bf82a9a08f655b4142ab6866f9bf2ad2bc63b2967c2ccd36ec55110a15162c24R1-R30) [[2]](diffhunk://#diff-ef56a9dd0b4a9d3d2de43fe3004ddfca4012a1910735c4ff3a0ed7591c517e5bR1-R30) [[3]](diffhunk://#diff-d9ea012cb8b9513928fff0846767b7f36ea92abc11622e7eb1ed760d56981ebcR1-R31)
* Introduced a `basestation.launch.py` file for managing GPS base station and joystick nodes.

### Science Subsystem Enhancements
* Added a `turnOnRaman.sh` script to run the Raman node with proper ROS and Python environment setup. This script is configured to run as a privileged user.
* Updated `setup/science/start_science.sh` to manage Docker containers for science-related ROS 2 nodes and stream camera data using GStreamer.

### Miscellaneous
* Renamed and updated `setup/setup_science.sh` to `setup/science/setup_science.sh`, including versioning and additional configurations.
* Added a new ROS 2 package (`src/bringup/package.xml`) for managing subsystem launch files.