### PR TITLE
fix: avoid checking for service, fire and forget

### DIFF
--- a/src/joystick_control/src/DriveMode.cpp
+++ b/src/joystick_control/src/DriveMode.cpp
@@ -87,13 +87,6 @@ void DriveMode::setServoPosition(int port, int position) const {
   auto request = std::make_shared<interfaces::srv::MoveServo::Request>();
   request->port = port;
   request->pos = position;
-
-  // Wait for the service to be available
-  if (!servo_client_->wait_for_service(std::chrono::seconds(1))) {
-    RCLCPP_WARN(node_->get_logger(), "Service not available after waiting");
-    return;
-  }
-
   servo_client_->async_send_request(request);
 }
 


### PR DESCRIPTION
We don't need to check since it takes longers than fire and forget.

Emergency Bug fix: Yolo merging