### PR TITLE
launch arm rviz on base station

### DIFF
--- a/src/bringup/launch/basestation.launch.py
+++ b/src/bringup/launch/basestation.launch.py
@@ -6,6 +6,7 @@ from launch.actions import IncludeLaunchDescription
 from ament_index_python.packages import get_package_share_directory
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 
+
 def generate_launch_description():
     return launch.LaunchDescription(
         [
@@ -28,10 +29,11 @@ def generate_launch_description():
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(
                     os.path.join(
-                        get_package_share_directory("arm_srdf"), "launch", "moveit_rviz.launch.py"
+                        get_package_share_directory("arm_srdf"),
+                        "launch",
+                        "moveit_rviz.launch.py",
                     )
                 )
-            )
-
+            ),
         ]
     )

--- a/src/bringup/launch/basestation.launch.py
+++ b/src/bringup/launch/basestation.launch.py
@@ -1,6 +1,10 @@
+import os
+
 import launch
 import launch_ros.actions
-
+from launch.actions import IncludeLaunchDescription
+from ament_index_python.packages import get_package_share_directory
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 
 def generate_launch_description():
     return launch.LaunchDescription(
@@ -21,5 +25,13 @@ def generate_launch_description():
                     {"Device": "/dev/ttyACM0"},
                 ],
             ),
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource(
+                    os.path.join(
+                        get_package_share_directory("arm_srdf"), "launch", "moveit_rviz.launch.py"
+                    )
+                )
+            )
+
         ]
     )


### PR DESCRIPTION
Launch rviz for the arm on the base station. It is easy to close for the 2 tasks we don't need it for.