### PR TITLE
fix: log management

### DIFF
--- a/src/bringup/launch/equipment_servicing.launch.py
+++ b/src/bringup/launch/equipment_servicing.launch.py
@@ -17,7 +17,7 @@ def get_included_launch_descriptions(launch_files):
 
 
 def generate_launch_description():
-    SetEnvironmentVariable('ROS_LOG_LEVEL', 'warn'),
+    SetEnvironmentVariable("ROS_LOG_LEVEL", "warn"),
     launch_files = [
         ("drive", "talon.launch.py"),
         ("arm_srdf", "servo.launch.py"),

--- a/src/bringup/launch/equipment_servicing.launch.py
+++ b/src/bringup/launch/equipment_servicing.launch.py
@@ -1,7 +1,7 @@
 from launch import LaunchDescription
 from launch_ros.substitutions import FindPackageShare
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.actions import IncludeLaunchDescription
+from launch.actions import IncludeLaunchDescription, SetEnvironmentVariable
 import os
 
 
@@ -17,6 +17,7 @@ def get_included_launch_descriptions(launch_files):
 
 
 def generate_launch_description():
+    SetEnvironmentVariable('ROS_LOG_LEVEL', 'warn'),
     launch_files = [
         ("drive", "talon.launch.py"),
         ("arm_srdf", "servo.launch.py"),

--- a/src/bringup/launch/nav.launch.py
+++ b/src/bringup/launch/nav.launch.py
@@ -17,7 +17,7 @@ def get_included_launch_descriptions(launch_files):
 
 
 def generate_launch_description():
-    SetEnvironmentVariable('ROS_LOG_LEVEL', 'info'),
+    SetEnvironmentVariable("ROS_LOG_LEVEL", "info"),
     launch_files = [
         ("drive", "talon.launch.py"),
         ("camera_streaming", "webRTC.launch.py"),

--- a/src/bringup/launch/nav.launch.py
+++ b/src/bringup/launch/nav.launch.py
@@ -1,7 +1,7 @@
 from launch import LaunchDescription
 from launch_ros.substitutions import FindPackageShare
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.actions import IncludeLaunchDescription
+from launch.actions import IncludeLaunchDescription, SetEnvironmentVariable
 import os
 
 
@@ -17,6 +17,7 @@ def get_included_launch_descriptions(launch_files):
 
 
 def generate_launch_description():
+    SetEnvironmentVariable('ROS_LOG_LEVEL', 'info'),
     launch_files = [
         ("drive", "talon.launch.py"),
         ("camera_streaming", "webRTC.launch.py"),

--- a/src/bringup/launch/science.launch.py
+++ b/src/bringup/launch/science.launch.py
@@ -1,7 +1,7 @@
 from launch import LaunchDescription
 from launch_ros.substitutions import FindPackageShare
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.actions import IncludeLaunchDescription
+from launch.actions import IncludeLaunchDescription, SetEnvironmentVariable
 import os
 
 
@@ -17,6 +17,7 @@ def get_included_launch_descriptions(launch_files):
 
 
 def generate_launch_description():
+    SetEnvironmentVariable('ROS_LOG_LEVEL', 'warn'),
     launch_files = [
         ("drive", "talon.launch.py"),
         ("camera_streaming", "webRTC.launch.py"),

--- a/src/bringup/launch/science.launch.py
+++ b/src/bringup/launch/science.launch.py
@@ -17,7 +17,7 @@ def get_included_launch_descriptions(launch_files):
 
 
 def generate_launch_description():
-    SetEnvironmentVariable('ROS_LOG_LEVEL', 'warn'),
+    SetEnvironmentVariable("ROS_LOG_LEVEL", "warn"),
     launch_files = [
         ("drive", "talon.launch.py"),
         ("camera_streaming", "webRTC.launch.py"),

--- a/src/bringup/launch/transversal.launch.py
+++ b/src/bringup/launch/transversal.launch.py
@@ -17,7 +17,7 @@ def get_included_launch_descriptions(launch_files):
 
 
 def generate_launch_description():
-    SetEnvironmentVariable('ROS_LOG_LEVEL', 'warn'),
+    SetEnvironmentVariable("ROS_LOG_LEVEL", "warn"),
     launch_files = [
         ("drive", "talon.launch.py"),
         ("arm_srdf", "servo.launch.py"),

--- a/src/bringup/launch/transversal.launch.py
+++ b/src/bringup/launch/transversal.launch.py
@@ -1,7 +1,7 @@
 from launch import LaunchDescription
 from launch_ros.substitutions import FindPackageShare
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.actions import IncludeLaunchDescription
+from launch.actions import IncludeLaunchDescription, SetEnvironmentVariable
 import os
 
 
@@ -17,6 +17,7 @@ def get_included_launch_descriptions(launch_files):
 
 
 def generate_launch_description():
+    SetEnvironmentVariable('ROS_LOG_LEVEL', 'warn'),
     launch_files = [
         ("drive", "talon.launch.py"),
         ("arm_srdf", "servo.launch.py"),

--- a/src/gps/gps/rtcm_pub_node.py
+++ b/src/gps/gps/rtcm_pub_node.py
@@ -135,7 +135,7 @@ class RtcmNode(Node):
             msg = Rtcm()
             msg.message = list(raw)
             self.rtcm_pub.publish(msg)
-            self.get_logger().info(
+            self.get_logger().debug(
                 f"Published RTCM message of length {len(raw)}. Parsed message: {parsed_data}"
             )
 

--- a/src/joystick_control/launch/controller.launch.py
+++ b/src/joystick_control/launch/controller.launch.py
@@ -18,7 +18,7 @@ def generate_launch_description():
                 name="flightstick_control",
                 output="screen",
                 parameters=[parameters_file],
-                arguments=['--ros-args', '--log-level', 'INFO']
+                arguments=["--ros-args", "--log-level", "INFO"],
             ),
         ]
     )

--- a/src/joystick_control/launch/controller.launch.py
+++ b/src/joystick_control/launch/controller.launch.py
@@ -18,6 +18,7 @@ def generate_launch_description():
                 name="flightstick_control",
                 output="screen",
                 parameters=[parameters_file],
+                arguments=['--ros-args', '--log-level', 'INFO']
             ),
         ]
     )


### PR DESCRIPTION
The log output is way to verbose. I set the default to just warnings, (except for nav which we want more info and have less to focus on other than output). I set flightstick controller to info to see the changing of states. What else do you want set to info?