### PR TITLE
Create dynamic replanning bt when path goes invalid

### DIFF
--- a/src/navigation/behavior_trees/bt_dynamic_replanning.xml
+++ b/src/navigation/behavior_trees/bt_dynamic_replanning.xml
@@ -1,0 +1,45 @@
+<!--
+  This Behavior Tree replans the global path once every 15 seconds or if the path becomes invalid. It also has
+  recovery actions specific to planning / control as well as general system issues.
+  This will be continuous if a kinematically valid planner is selected.
+-->
+<root main_tree_to_execute="MainTree">
+  <BehaviorTree ID="MainTree">
+    <RecoveryNode number_of_retries="6" name="NavigateRecovery">
+      <PipelineSequence name="NavigateWithReplanning">
+        <RateController hz="2.0">
+          <RecoveryNode number_of_retries="1" name="ComputePathToPose">
+            <Fallback>
+              <ReactiveSequence>
+                <Inverter>
+                  <PathExpiringTimer seconds="10" path="{path}"/>
+                </Inverter>
+                <Inverter>
+                  <GlobalUpdatedGoal/>
+                </Inverter>
+                <IsPathValid path="{path}"/>
+              </ReactiveSequence>
+              <ComputePathToPose goal="{goal}" path="{path}" planner_id="GridBased"/>
+            </Fallback>
+            <ClearEntireCostmap name="ClearGlobalCostmap-Context" service_name="global_costmap/clear_entirely_global_costmap"/>
+          </RecoveryNode>
+        </RateController>
+        <RecoveryNode number_of_retries="1" name="FollowPath">
+          <FollowPath path="{path}" controller_id="FollowPath"/>
+          <ClearEntireCostmap name="ClearLocalCostmap-Context" service_name="local_costmap/clear_entirely_local_costmap"/>
+        </RecoveryNode>
+      </PipelineSequence>
+      <ReactiveFallback name="RecoveryFallback">
+        <GoalUpdated/>
+        <RoundRobin name="RecoveryActions">
+          <Sequence name="ClearingActions">
+            <ClearEntireCostmap name="ClearLocalCostmap-Subtree" service_name="local_costmap/clear_entirely_local_costmap"/>
+            <ClearEntireCostmap name="ClearGlobalCostmap-Subtree" service_name="global_costmap/clear_entirely_global_costmap"/>
+          </Sequence>
+          <Wait wait_duration="2"/>
+          <BackUp backup_dist="1.0" backup_speed="0.15"/>
+        </RoundRobin>
+      </ReactiveFallback>
+    </RecoveryNode>
+  </BehaviorTree>
+</root>

--- a/src/navigation/launch/nav2.launch.py
+++ b/src/navigation/launch/nav2.launch.py
@@ -27,6 +27,9 @@ from nav2_common.launch import RewrittenYaml
 
 
 def generate_launch_description():
+    # Constants
+    DEFAULT_BT_XML_FILENAME = "bt_dynamic_replanning.xml"
+
     # Get the launch directory
     bringup_dir = get_package_share_directory("nav2_bringup")
     pkg_dir = get_package_share_directory("navigation")
@@ -129,7 +132,7 @@ def generate_launch_description():
 
     default_bt_xml_filename_cmd = DeclareLaunchArgument(
         "default_nav_to_pose_bt_xml",
-        default_value=os.path.join(pkg_dir, "behavior_trees", "behaviorTree.xml"),
+        default_value=os.path.join(pkg_dir, "behavior_trees", DEFAULT_BT_XML_FILENAME),
         description="Full path to the behavior tree xml file to use",
     )
 


### PR DESCRIPTION
This is the behaviour tree from here: https://discourse.ros.org/t/nav2-feedback-required-potential-change-to-default-behavior/24687

Jira task ROVER-417.

This BT tree will only plan every 15 seconds but then also replan if the path goes invalid which is checked every 0.5 seconds.

