### PR TITLE
Video restart

### DIFF
--- a/setup/firstTimeInstall.sh
+++ b/setup/firstTimeInstall.sh
@@ -28,3 +28,9 @@ sudo chmod 755 /usr/local/bin/turnOnRaman.sh
 echo "${SUDO_USER:-$USER} ALL=(ALL) NOPASSWD: /usr/local/bin/turnOnRaman.sh" \
   | sudo tee /etc/sudoers.d/turnonraman >/dev/null
 sudo chmod 0440 /etc/sudoers.d/turnonraman
+
+UDEV_RULE='SUBSYSTEM=="video4linux", ATTR{name}=="Arducam B0495 (USB3 2.3MP)", ATTRS{idVendor}=="04b4", ATTR{index}=="0", ATTRS{idProduct}=="0495", SYMLINK+="drive_camera", MODE="0666"'
+echo "$UDEV_RULE" | sudo tee /etc/udev/rules.d/99-arducam.rules > /dev/null
+
+sudo udevadm control --reload-rules
+sudo udevadm trigger

--- a/src/camera_streaming/CMakeLists.txt
+++ b/src/camera_streaming/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_CXX_STANDARD 20)
 # Find dependencies (ROS2, GStreamer, and PkgConfig)
 find_package(rclcpp REQUIRED)
 find_package(interfaces REQUIRED)
+find_package(std_srvs REQUIRED)
 
 # Use pkg-config to find the necessary GStreamer libraries
 find_package(PkgConfig REQUIRED)
@@ -45,7 +46,11 @@ target_link_libraries(webrtc_node
 pkg_check_modules(GLIB REQUIRED glib-2.0)
 
 # Set up any necessary ROS2 specific configurations
-ament_target_dependencies(webrtc_node rclcpp interfaces)
+ament_target_dependencies(webrtc_node 
+  rclcpp
+  interfaces
+  std_srvs
+)
 
 # Install header files
 install(DIRECTORY include/

--- a/src/camera_streaming/config/webrtc.yaml
+++ b/src/camera_streaming/config/webrtc.yaml
@@ -9,7 +9,7 @@ webrtc_node:
     - "Microscope"
     - "Panoramic"
     Drive:
-      path: "/dev/v4l/by-id/usb-Arducam_Arducam_B0495__USB3_2.3MP__Arducam_20231205_0001-video-index0"
+      path: "/dev/drive_camera"
       type: 0
     EndEffector:
       path: "/dev/v4l/by-id/usb-Sonix_Technology_Co.__Ltd._USB_2.0_Camera_SN5100-video-index0"

--- a/src/camera_streaming/include/camera_streaming/webrtc_node.h
+++ b/src/camera_streaming/include/camera_streaming/webrtc_node.h
@@ -77,9 +77,13 @@ class WebRTCStreamer : public rclcpp::Node {
 
  private:
   /**
-   * @brief Initializes the GStreamer pipeline and sets up services.
+   * @brief Initializes the GStreamer pipeline
    */
   bool start();
+  /**
+   * @brief Shuts down and cleans up the gstreamer pipeline resources
+   */
+  void stop();
 
   /**
    * @brief Declares parameters for the WebRTCStreamer node.
@@ -191,9 +195,8 @@ class WebRTCStreamer : public rclcpp::Node {
                              std::string element_name = "");
 
   bool web_server_; /**< Flag indicating if the web server is enabled */
-  std::string web_server_path_; /**< Path to the web server */
-  std::vector<GstElement*>
-      connected_sources_; /**< List of connected GStreamer source elements */
+  std::string web_server_path_;       /**< Path to the web server */
+  std::vector<GstElement*> elements_; /**< List of GStreamer elements */
   GstUniquePtr<GstElement> pipeline_; /**< GStreamer pipeline element */
   GstElement* compositor_;            /**< GStreamer compositor element */
   rclcpp::Service<interfaces::srv::VideoOut>::SharedPtr

--- a/src/camera_streaming/include/camera_streaming/webrtc_node.h
+++ b/src/camera_streaming/include/camera_streaming/webrtc_node.h
@@ -17,6 +17,7 @@
 #include <interfaces/srv/video_out.hpp>
 #include <map>
 #include <rclcpp/rclcpp.hpp>
+#include <std_srvs/srv/trigger.hpp>
 #include <string>
 #include <vector>
 
@@ -76,6 +77,19 @@ class WebRTCStreamer : public rclcpp::Node {
 
  private:
   /**
+   * @brief Initializes the GStreamer pipeline and sets up services.
+   */
+  bool start();
+
+  /**
+   * @brief Declares parameters for the WebRTCStreamer node.
+   *
+   * This function declares parameters such as web server settings, camera
+   * names, and camera properties.
+   */
+  void declare_parameters();
+
+  /**
    * @brief Callback function to start video streaming.
    *
    * @param request The request object containing video output parameters.
@@ -105,6 +119,16 @@ class WebRTCStreamer : public rclcpp::Node {
   void get_cameras(
       const std::shared_ptr<interfaces::srv::GetCameras::Request> request,
       std::shared_ptr<interfaces::srv::GetCameras::Response> response);
+
+  /**
+   * @brief Callback function to restart the video pipeline.
+   *
+   * @param request The request object (not used).
+   * @param response The response object to be populated with the result.
+   */
+  void restart_pipeline(
+      const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+      std::shared_ptr<std_srvs::srv::Trigger::Response> response);
 
   /**
    * @brief Creates a GStreamer source element for the given camera source.
@@ -177,7 +201,9 @@ class WebRTCStreamer : public rclcpp::Node {
   rclcpp::Service<interfaces::srv::VideoCapture>::SharedPtr
       capture_service_; /**< ROS2 service for capturing frames */
   rclcpp::Service<interfaces::srv::GetCameras>::SharedPtr
-      get_cams_service_;     /**< ROS2 service for getting camera list */
+      get_cams_service_; /**< ROS2 service for getting camera list */
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr
+      restart_service_; /**< ROS2 service for restarting the video pipeline */
   GstUniquePtr<GstBus> bus_; /**< GStreamer bus for message handling */
   std::map<std::string, GstUniquePtr<GstPad>>
       source_pads_; /**< Maps camera names to compositor pads*/

--- a/src/camera_streaming/package.xml
+++ b/src/camera_streaming/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>rclcpp</depend>
   <depend>interfaces</depend>
+  <depend>std_srvs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/src/camera_streaming/src/webrtc_node.cpp
+++ b/src/camera_streaming/src/webrtc_node.cpp
@@ -12,12 +12,8 @@ WebRTCStreamer::WebRTCStreamer()
   gst_init(nullptr, nullptr);
 
   // Declare parameters
-  this->declare_parameter("web_server", true);
-  this->declare_parameter("web_server_path", ".");
-  this->declare_parameter("max_width", 1280);
-  this->declare_parameter("max_height", 720);
-  this->declare_parameter("max_framerate", 30);
-  this->declare_parameter("camera_name", std::vector<std::string>());
+  declare_parameters();
+
   this->get_parameter("web_server", web_server_);
   this->get_parameter("web_server_path", web_server_path_);
   this->get_parameter("max_width", width_);
@@ -34,21 +30,35 @@ WebRTCStreamer::WebRTCStreamer()
   get_cams_service_ = this->create_service<interfaces::srv::GetCameras>(
       "get_cameras", std::bind(&WebRTCStreamer::get_cameras, this,
                                std::placeholders::_1, std::placeholders::_2));
+  restart_service_ = this->create_service<std_srvs::srv::Trigger>(
+      "reset_video", std::bind(&WebRTCStreamer::restart_pipeline, this,
+                               std::placeholders::_1, std::placeholders::_2));
 
+  start();
+  GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(pipeline_.get()), GST_DEBUG_GRAPH_SHOW_ALL,
+                            "start_pipeline");
+}
+
+WebRTCStreamer::~WebRTCStreamer() {
+  for (auto it = source_pads_.cbegin(); it != source_pads_.end(); ++it) {
+    gst_element_release_request_pad(compositor_, it->second.get());
+  }
+  if (pipeline_) {
+    gst_element_set_state(pipeline_.get(), GST_STATE_NULL);
+  }
+}
+
+bool WebRTCStreamer::start() {
   // Fetch camera parameters
-  std::vector<std::string> camera_name;
-  this->get_parameter("camera_name", camera_name);
+  std::vector<std::string> camera_names;
+  this->get_parameter("camera_name", camera_names);
   initialize_pipeline();
 
-  for (const auto &name : camera_name) {
+  for (const auto &name : camera_names) {
     std::string camera_path;
-    this->declare_parameter(name + ".path", "");
     this->get_parameter(name + ".path", camera_path);
-    this->declare_parameter(name + ".type",
-                            static_cast<int>(CameraType::V4l2Src));
     int camera_type;
     this->get_parameter(name + ".type", camera_type);
-    this->declare_parameter(name + ".encoded", false);
     bool encoded;
     this->get_parameter(name + ".encoded", encoded);
     CameraSource source;
@@ -87,21 +97,28 @@ WebRTCStreamer::WebRTCStreamer()
     }
   }
   const auto ret = gst_element_set_state(pipeline_.get(), GST_STATE_PLAYING);
-  if (ret != GST_STATE_CHANGE_FAILURE) {
-    RCLCPP_INFO(this->get_logger(), "Pipeline started successfully");
-  } else {
+  if (ret == GST_STATE_CHANGE_FAILURE) {
     RCLCPP_ERROR(this->get_logger(), "Failed to start pipeline");
+    return false;
   }
-  GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(pipeline_.get()), GST_DEBUG_GRAPH_SHOW_ALL,
-                            "start_pipeline");
+  RCLCPP_INFO(this->get_logger(), "Pipeline started successfully");
+  return true;
 }
 
-WebRTCStreamer::~WebRTCStreamer() {
-  for (auto it = source_pads_.cbegin(); it != source_pads_.end(); ++it) {
-    gst_element_release_request_pad(compositor_, it->second.get());
-  }
-  if (pipeline_) {
-    gst_element_set_state(pipeline_.get(), GST_STATE_NULL);
+void WebRTCStreamer::declare_parameters() {
+  this->declare_parameter("web_server", true);
+  this->declare_parameter("web_server_path", ".");
+  this->declare_parameter("max_width", 1280);
+  this->declare_parameter("max_height", 720);
+  this->declare_parameter("max_framerate", 30);
+  this->declare_parameter("camera_name", std::vector<std::string>());
+  std::vector<std::string> camera_name;
+  this->get_parameter("camera_name", camera_name);
+  for (const auto &name : camera_name) {
+    this->declare_parameter(name + ".path", std::string());
+    this->declare_parameter(name + ".type",
+                            static_cast<int>(CameraType::V4l2Src));
+    this->declare_parameter(name + ".encoded", false);
   }
 }
 
@@ -130,7 +147,7 @@ void WebRTCStreamer::start_video_cb(
     response->success = false;
   }
   GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(pipeline_.get()), GST_DEBUG_GRAPH_SHOW_ALL,
-                            "pipeline");
+                            "pipeline_update");
 }
 
 void WebRTCStreamer::capture_frame(
@@ -233,6 +250,23 @@ void WebRTCStreamer::get_cameras(
   for (auto it = source_pads_.cbegin(); it != source_pads_.end(); ++it) {
     response->sources.push_back(it->first);
   }
+}
+
+void WebRTCStreamer::restart_pipeline(
+    const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
+  if (pipeline_) {
+    gst_element_set_state(pipeline_.get(), GST_STATE_NULL);
+  }
+  response->success = start();
+  if (response->success) {
+    response->message = "Pipeline restarted successfully";
+  } else {
+    response->message = "Failed to restart pipeline";
+  }
+  GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(pipeline_.get()), GST_DEBUG_GRAPH_SHOW_ALL,
+                            "restart_pipeline");
+  RCLCPP_INFO(this->get_logger(), "%s", response->message.c_str());
 }
 
 GstElement *WebRTCStreamer::create_vid_conv() {


### PR DESCRIPTION
This PR is for [ROVER-400](https://jira.engsoc.net/browse/ROVER-400)

Cleans up memory leaks in the shutdown procedure to allow for restarting without shutting down the whole node.

Also fixes the bug where the drive camera sometimes comes back as a different symlink by making my own udev rule