### PR TITLE
[ROVER-416] Joystick Mode Check

### DIFF
--- a/src/joystick_control/include/joystick_control/FlightstickControl.hpp
+++ b/src/joystick_control/include/joystick_control/FlightstickControl.hpp
@@ -94,6 +94,17 @@ class FlightstickControl : public rclcpp::Node {
   bool checkForModeChange(std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg);
 
   /**
+   * @brief Checks all axis and button values
+   *
+   * This function checks if all relevant axis and button values are 0
+   *
+   * @param joystickMsg A shared pointer to the received joystick message.
+   * @p
+   * @return True if all axes (except slider) are 0, false otherwise
+   */
+  bool checkAxes(std::shared_ptr<sensor_msgs::msg::Joy> joystickMsg);
+
+  /**
    * @brief Changes the control mode.
    *
    * This function changes the control mode of the rover to the specified mode.

--- a/src/science_sensors/science_sensors/microscope_control.py
+++ b/src/science_sensors/science_sensors/microscope_control.py
@@ -7,7 +7,6 @@ from geometry_msgs.msg import Twist
 
 
 class microscope_control(Node):
-
     def __init__(self):
         super().__init__("microscope_control")
         self.cli = self.create_client(MoveServo, "servo_service")


### PR DESCRIPTION
For [ROVER-416](https://jira.engsoc.net/secure/RapidBoard.jspa?rapidView=34&projectKey=ROVER&view=planning&selectedIssue=ROVER-416&quickFilter=128&quickFilter=119&issueLimit=100#)

Added a check to the Flightstick control to only allow mode changes if all non-slider axes are 0.