### PR TITLE
fix: ROVER-426 and crash with no moveit servo running

### DIFF
--- a/src/joystick_control/src/ArmHelpers.cpp
+++ b/src/joystick_control/src/ArmHelpers.cpp
@@ -10,7 +10,7 @@ bool ArmHelpers::start_moveit_servo(rclcpp::Node* node, int attempts) {
     RCLCPP_WARN(node->get_logger(), "Service not available, Waiting...");
     if (++i >= attempts) {
       RCLCPP_ERROR(node->get_logger(),
-                   "Service not available after %d attempts. Quiting...", i);
+                   "Service not available after %d attempts. Giving up", i);
       return false;
     }
   }

--- a/src/joystick_control/src/ArmIKMode.cpp
+++ b/src/joystick_control/src/ArmIKMode.cpp
@@ -12,7 +12,8 @@ ArmIKMode::ArmIKMode(rclcpp::Node* node) : Mode("IK Arm", node) {
   twist_pub_ = node_->create_publisher<geometry_msgs::msg::TwistStamped>(
       "/servo_node/delta_twist_cmds", 10);
   if (!ArmHelpers::start_moveit_servo(node_)) {
-    return;
+    RCLCPP_ERROR(node_->get_logger(),
+                 "Failed to start MoveIt servo service, IK mode will not work");
   }
 
   auto stop_hw_interface_pub =

--- a/src/joystick_control/src/ArmManualMode.cpp
+++ b/src/joystick_control/src/ArmManualMode.cpp
@@ -12,7 +12,9 @@ ArmManualMode::ArmManualMode(rclcpp::Node* node) : Mode("Manual Arm", node) {
   servo_client_ =
       node_->create_client<interfaces::srv::MoveServo>("servo_service");
   if (!ArmHelpers::start_moveit_servo(node_)) {
-    return;
+    RCLCPP_ERROR(
+        node_->get_logger(),
+        "Failed to start MoveIt servo service, Manual mode will not work");
   }
 
   auto stop_hw_interface_pub =

--- a/src/joystick_control/src/FlightstickControl.cpp
+++ b/src/joystick_control/src/FlightstickControl.cpp
@@ -13,7 +13,7 @@ FlightstickControl::FlightstickControl()
                 std::placeholders::_1));
 
   status_pub_ = this->create_publisher<std_msgs::msg::String>(
-      "/flightstick/status", rclcpp::QoS(rclcpp::KeepLast(10)).reliable());
+      "/rover_mode", rclcpp::QoS(rclcpp::KeepLast(10)).reliable());
   rclcpp::QoS qos(rclcpp::KeepLast(10));
   qos.reliability(RMW_QOS_POLICY_RELIABILITY_RELIABLE);
   light_pub_ = this->create_publisher<std_msgs::msg::Int8>("/light", qos);


### PR DESCRIPTION

1. Fixes https://jira.engsoc.net/browse/ROVER-426
2. Fixes a seg fault when the constructor left early due to no moveit servo. Warn the user drastically then move on.